### PR TITLE
Add RenderContext affordance

### DIFF
--- a/src/lib/completion-components.tsx
+++ b/src/lib/completion-components.tsx
@@ -2,14 +2,17 @@ import { openAIChat } from '../lib/models';
 import { LLMx, Models } from '../lib';
 import { ChatCompletionRequestMessage } from 'openai';
 
-export async function* Completion(props: {
-  temperature?: number;
-  maxTokens?: number;
-  stop?: string[];
-  children: LLMx.Node;
-}) {
+export async function* Completion(
+  props: {
+    temperature?: number;
+    maxTokens?: number;
+    stop?: string[];
+    children: LLMx.Node;
+  },
+  { render }: LLMx.RenderContext
+) {
   yield '▁';
-  let prompt = await LLMx.render(props.children);
+  let prompt = await render(props.children);
   while (prompt.length > 0 && prompt.endsWith(' ')) {
     prompt = prompt.slice(0, prompt.length - 1);
   }
@@ -41,15 +44,18 @@ export function AssistantMessage({ children }: { children: LLMx.Node }) {
   return children;
 }
 
-export async function* ChatCompletion(props: {
-  temperature?: number;
-  maxTokens?: number;
-  stop?: string[];
-  children: LLMx.Node;
-}) {
+export async function* ChatCompletion(
+  props: {
+    temperature?: number;
+    maxTokens?: number;
+    stop?: string[];
+    children: LLMx.Node;
+  },
+  { render, partialRender }: LLMx.RenderContext
+) {
   yield '▁';
 
-  const messageElements = await LLMx.partialRender(
+  const messageElements = await partialRender(
     props.children,
     (e) => e.tag == SystemMessage || e.tag == UserMessage || e.tag == AssistantMessage
   );
@@ -60,18 +66,18 @@ export async function* ChatCompletion(props: {
         case SystemMessage:
           return {
             role: 'system',
-            content: await LLMx.render(message),
+            content: await render(message),
           };
         case UserMessage:
           return {
             role: 'user',
-            content: await LLMx.render(message),
+            content: await render(message),
             name: (message.props as LLMx.PropsOfComponent<typeof UserMessage>).name,
           };
         case AssistantMessage:
           return {
             role: 'assistant',
-            content: await LLMx.render(message),
+            content: await render(message),
           };
         default:
           throw new Error(

--- a/src/lib/debug.tsx
+++ b/src/lib/debug.tsx
@@ -1,6 +1,6 @@
 import { LLMx } from '../lib';
 
-export async function* DebugTree(props: { children: LLMx.Node }) {
+export async function* DebugTree(props: { children: LLMx.Node }, { partialRenderStream }: LLMx.RenderContext) {
   let current = props.children;
   while (true) {
     yield LLMx.debug(<DebugTree {...props}>{current}</DebugTree>);
@@ -17,7 +17,7 @@ export async function* DebugTree(props: { children: LLMx.Node }) {
     // https://github.com/microsoft/TypeScript/issues/9998#issuecomment-235963457
     const didRenderSomething = () => elementToRender !== null;
 
-    for await (const frame of LLMx.partialRenderStream(current, shouldStop)) {
+    for await (const frame of partialRenderStream(current, shouldStop)) {
       current = frame;
       yield LLMx.debug(<DebugTree {...props}>{current}</DebugTree>);
     }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -2,12 +2,12 @@ import * as readline from 'readline/promises';
 import { log } from './';
 import { v4 as uuidv4 } from 'uuid';
 
-export type Component<P> = (props: P) => Renderable;
+export type Component<P> = (props: P, renderContext: RenderContext) => Renderable;
 export type Literal = string | number | null | undefined | boolean;
 export interface Element<P extends {}> {
   tag: Component<P>;
   props: P;
-  render: () => Renderable;
+  render: (renderContext: RenderContext) => Renderable;
 }
 export type Node = Element<any> | Literal | Node[];
 
@@ -16,32 +16,43 @@ export type Renderable = Node | Promise<Renderable> | AsyncGenerator<Renderable>
 export type ElementPredicate = (e: Element<any>) => boolean;
 export type PropsOfComponent<T extends Component<any>> = T extends Component<infer P> ? P : never;
 
+export interface RenderContext {
+  partialRenderStream(renderable: Renderable, shouldStop: ElementPredicate): AsyncGenerator<PartiallyRendered[]>;
+  partialRender(renderable: Renderable, shouldStop: ElementPredicate): Promise<PartiallyRendered[]>;
+  renderStream(renderable: Renderable): AsyncGenerator<string>;
+  render(renderable: Renderable): Promise<string>;
+}
+
 export declare namespace JSX {
   interface ElementChildrenAttribute {
     children: {};
   }
 }
 
-export function createElement<T extends Component<P>, P extends { children: C }, C>(
-  tag: T,
-  props: Omit<P, 'children'>,
-  child: C
+export function createElement<P extends { children: C }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
+  ...children: [C]
 ): Element<P>;
-export function createElement<T extends Component<P>, P extends { children: C[] }, C>(
-  tag: T,
-  props: Omit<P, 'children'>,
+export function createElement<P extends { children: C[] }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
   ...children: C[]
 ): Element<P>;
-export function createElement(tag: any, props: any, ...children: any[]): Element<any> {
+export function createElement<P extends { children: C | C[] }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
+  ...children: C[]
+): Element<P> {
   const propsToPass = {
     ...(props ?? {}),
     children: children.length == 1 ? children[0] : children,
-  };
+  } as P;
 
   const result = {
     tag,
     props: propsToPass,
-    render: () => tag(propsToPass),
+    render: (ctx: RenderContext) => tag(propsToPass, ctx),
   };
   Object.freeze(propsToPass);
   Object.freeze(result);
@@ -149,7 +160,8 @@ export function debug(value: unknown, indent: string = '', context: 'code' | 'ch
 
 type PartiallyRendered = string | Element<any>;
 
-export async function* partialRenderStream(
+async function* partialRenderStream(
+  context: RenderContext,
   renderable: Renderable,
   shouldStop: ElementPredicate
 ): AsyncGenerator<PartiallyRendered[]> {
@@ -182,7 +194,7 @@ export async function* partialRenderStream(
     };
 
     const inProgressRenders = renderable.map((r) => {
-      const generator = partialRenderStream(r, shouldStop);
+      const generator = context.partialRenderStream(r, shouldStop);
       const inProgressRender: InProgressRender = {
         generator,
         currentValue: [],
@@ -217,36 +229,37 @@ export async function* partialRenderStream(
     if (shouldStop(renderable)) {
       yield [renderable];
     } else {
-      yield* partialRenderStream(renderable.render(), shouldStop);
+      yield* context.partialRenderStream(renderable.render(context), shouldStop);
     }
   } else if (renderable instanceof Promise) {
-    yield* await renderable.then((x) => partialRenderStream(x, shouldStop));
+    yield* await renderable.then((x) => context.partialRenderStream(x, shouldStop));
   } else {
     // Exhaust the iterator.
     for await (const value of renderable) {
-      yield* partialRenderStream(value, shouldStop);
+      yield* context.partialRenderStream(value, shouldStop);
     }
   }
 }
 
-export async function partialRender(
+async function partialRender(
+  context: RenderContext,
   renderable: Renderable,
   shouldStop: ElementPredicate
 ): Promise<PartiallyRendered[]> {
   let lastValue: PartiallyRendered[] = [];
-  for await (const value of partialRenderStream(renderable, shouldStop)) {
+  for await (const value of context.partialRenderStream(renderable, shouldStop)) {
     lastValue = value;
   }
   return lastValue;
 }
 
-export async function render(renderable: Renderable): Promise<string> {
-  const elementsOrStrings = await partialRender(renderable, () => false);
+async function render(context: RenderContext, renderable: Renderable): Promise<string> {
+  const elementsOrStrings = await context.partialRender(renderable, () => false);
   return elementsOrStrings.join('');
 }
 
-export async function* renderStream(renderable: Renderable): AsyncGenerator<string> {
-  for await (const value of partialRenderStream(renderable, () => false)) {
+async function* renderStream(context: RenderContext, renderable: Renderable): AsyncGenerator<string> {
+  for await (const value of context.partialRenderStream(renderable, () => false)) {
     yield value.join('');
   }
 }
@@ -256,8 +269,21 @@ interface ShowOptions {
   step: boolean;
 }
 
+export function createRenderContext(): RenderContext {
+  const context: RenderContext = {
+    partialRenderStream: (renderable, shouldStop) => partialRenderStream(context, renderable, shouldStop),
+    partialRender: (renderable, shouldStop) => partialRender(context, renderable, shouldStop),
+    renderStream: (renderable) => renderStream(context, renderable),
+    render: (renderable) => render(context, renderable),
+  };
+
+  return context;
+}
+
 export function show(node: Node, opts: ShowOptions | undefined = { stream: true, step: false }) {
   const showLifespanId = uuidv4();
+
+  const renderContext = createRenderContext();
   return log.logPhase({ phase: 'show', level: 'trace', opts, showLifespanId }, async () => {
     if (opts.stream) {
       if (process.env.loglevel) {
@@ -265,14 +291,14 @@ export function show(node: Node, opts: ShowOptions | undefined = { stream: true,
           {},
           'show() called with stream=true, but env var `loglevel` is set. Streaming and console logging at the same time will lead to broken output. As a fallback, show() will not stream.'
         );
-        console.log(await render(node));
+        console.log(await renderContext.render(node));
         return;
       }
 
       const rl = readline.createInterface(process.stdin, process.stdout);
       let lastPage = '';
       const cursor = new readline.Readline(process.stdout);
-      for await (const page of renderStream(node)) {
+      for await (const page of renderContext.renderStream(node)) {
         for (const line of lastPage.split('\n').reverse()) {
           cursor.clearLine(0);
           cursor.moveCursor(-line.length, -1);
@@ -292,7 +318,7 @@ export function show(node: Node, opts: ShowOptions | undefined = { stream: true,
       return;
     }
 
-    console.log(await render(node));
+    console.log(await renderContext.render(node));
   });
 }
 

--- a/src/lib/memoize.tsx
+++ b/src/lib/memoize.tsx
@@ -17,17 +17,18 @@ export function memo(renderable: LLMx.Renderable): LLMx.Node {
       return renderable;
     }
 
-    let memoizedValue: LLMx.Renderable = undefined;
-    let isMemoized: boolean = false;
-
+    // N.B. The memoization applies per-RenderContext -- if the same component is rendered under
+    // two different RenderContexts, it won't be memoized.
+    const memoizedValues = new WeakMap<LLMx.RenderContext, LLMx.Renderable>();
     const newElement = {
       ...renderable,
-      render: () => {
-        if (!isMemoized) {
-          memoizedValue = memo(renderable.render());
-          isMemoized = true;
+      render: (ctx: LLMx.RenderContext) => {
+        if (memoizedValues.has(ctx)) {
+          return memoizedValues.get(ctx);
         }
 
+        const memoizedValue = memo(renderable.render(ctx));
+        memoizedValues.set(ctx, memoizedValue);
         return memoizedValue;
       },
     };
@@ -44,6 +45,7 @@ export function memo(renderable: LLMx.Renderable): LLMx.Node {
     const MemoizedPromise = () => memoizedRenderable;
     return <MemoizedPromise id={++memoizedId} {...{ [isMemoizedSymbol]: true }} />;
   }
+
   // It's an async generator (which is mutable). We set up some machinery to buffer the
   // results so that we can create memoized generators as necessary.
   const generator = renderable;


### PR DESCRIPTION
This adds a second `RenderContext` argument to all components, into which the `render` family of functions has moved. Subsequent changes will add mechanisms by which this context can vary across the tree.

One change of note is that memoization is now `RenderContext`-identify specific (via `WeakMap`), i.e. rendering a memoized component into two different `RenderContexts` will cause two renders.