### PR TITLE
Removing clipLongPrompt from ImageGen

### DIFF
--- a/packages/ai-jsx/src/core/image-gen.tsx
+++ b/packages/ai-jsx/src/core/image-gen.tsx
@@ -7,8 +7,6 @@ export interface ImageGenProps {
   numSamples?: number;
   /** defines the image resolution */
   size?: '256x256' | '512x512' | '1024x1024';
-  /** if true, will clip prompts that are too long */
-  clipLongPrompt?: boolean;
 }
 
 export type ImageGenPropsWithChildren = ImageGenProps & {

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -303,16 +303,10 @@ export async function* OpenAIChatModel(
  *          If numSamples is greater than 1, URLs are separated by newlines.
  */
 export async function DalleImageGen(
-  { numSamples = 1, size = '512x512', clipLongPrompt = true, children }: ImageGenPropsWithChildren,
+  { numSamples = 1, size = '512x512', children }: ImageGenPropsWithChildren,
   { render, getContext, logger }: LLMx.ComponentContext
 ) {
-  let prompt = await render(children);
-
-  // TODO: I only found the maximum length in their docs, not in the API itself.
-  const maxPromptLength = 1000;
-  if (clipLongPrompt && prompt.length > maxPromptLength) {
-    prompt = `${prompt.substring(0, maxPromptLength - 4)} ...`;
-  }
+  const prompt = await render(children);
 
   const openai = getContext(openAiClientContext);
 

--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -209,7 +209,7 @@ function WriteStoryWithImage() {
 }
 ```
 
-We use a second LLM pass to create a description for the image. We then feed this description to an `<ImageGen>` compoent.
+We use a second LLM pass to create a description for the image. We then feed this description to an `<ImageGen>` component.
 `<ImageGen>` by default uses [Dalle](https://platform.openai.com/docs/guides/images/introduction).
 
 Note that we also used a new component, `memo`. If we simply use `<WriteStory />` twice (even if you assign it to a variable), you will have two separate LLM calls and possibly two different stories as a result.

--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -186,14 +186,22 @@ $ grep -i 'starting modelcall' packages/ai-jsx/llmx.log | yarn workspace ai-jsx 
 
 ## Beyond Text: Image Generation
 
-You are not restricted by text models. Let's create an image for the story as well:
+You are not restricted to text models. Let's create an image for the story as well:
 
 ```tsx title="index.tsx"
-function StoryWithImage() {
+function WriteStoryWithImage() {
   const story = memo(<WriteStory />);
   return (
     <>
-      Banner URL: <ImageGen clipLongPrompt>Generate an image for this story: {story}</ImageGen>
+      Banner URL:{' '}
+      <ImageGen>
+        <ChatCompletion>
+          <UserMessage>
+            You are an artist. You are creating a sketch for a new book. Concisely describe a sketch for scene from the
+            following story: {story}
+          </UserMessage>
+        </ChatCompletion>
+      </ImageGen>
       {'\n\n'}
       {story}
     </>
@@ -201,8 +209,8 @@ function StoryWithImage() {
 }
 ```
 
-The `<ImageGen>` by default uses [Dalle](https://platform.openai.com/docs/guides/images/introduction).
-Since the story will likely be longer than the model's prompt length, we allow the model to clip it using the `clipLongPrompt` parameter.
+We use a second LLM pass to create a description for the image. We then feed this description to an `<ImageGen>` compoent.
+`<ImageGen>` by default uses [Dalle](https://platform.openai.com/docs/guides/images/introduction).
 
 Note that we also used a new component, `memo`. If we simply use `<WriteStory />` twice (even if you assign it to a variable), you will have two separate LLM calls and possibly two different stories as a result.
 For reference see [Memoization](guides/rules-of-jsx.md#Memoization).

--- a/packages/examples/src/getting-started/index.tsx
+++ b/packages/examples/src/getting-started/index.tsx
@@ -71,7 +71,15 @@ function WriteStoryWithImage() {
   const story = memo(<WriteStory />);
   return (
     <>
-      Banner URL: <ImageGen clipLongPrompt>Generate an image for this story: {story}</ImageGen>
+      Banner URL:{' '}
+      <ImageGen>
+        <ChatCompletion>
+          <UserMessage>
+            You are an artist. You are creating a sketch for a new book. Concisely describe a sketch for scene from the
+            following story: {story}
+          </UserMessage>
+        </ChatCompletion>
+      </ImageGen>
       {'\n\n'}
       {story}
     </>


### PR DESCRIPTION
Removing the `clipLongPrompt` option from `<ImageGen>` component based on comments from @NickHeiner and @juberti.
The idea is to officially add `Summarizer` types and also use context to learn about how long the text should be in later PRs instead of the `clipLongPrompt` option.