### PR TITLE
Disable function mangling in CRA demo

### DIFF
--- a/packages/create-react-app-demo/config/webpack.config.cjs
+++ b/packages/create-react-app-demo/config/webpack.config.cjs
@@ -241,8 +241,10 @@ module.exports = function (webpackEnv) {
               // Pending further investigation:
               // https://github.com/terser-js/terser/issues/120
               inline: 2,
+              keep_fnames: true,
             },
             mangle: {
+              keep_fnames: true,
               safari10: true,
             },
             // Added for profiling in devtools


### PR DESCRIPTION
Serializing a React tree into text doesn't work well if function names are mangled. (Namely it prevents the LLM from using inferring component semantics from the name.)