### PR TITLE
Set a fake openai api key when running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       - run: YARN_CHECKSUM_BEHAVIOR=ignore ~/.volta/bin/yarn install --immutable
       - run: ~/.volta/bin/yarn test
         env:
-          OPENAI_API_KEY: "FAKE-OPENAI-API-KEY"
+          OPENAI_API_KEY: 'FAKE-OPENAI-API-KEY'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,6 @@ jobs:
       # I added this to suppress this warning:
       #     YN0018: typescript@patch:typescript@npm%3A5.1.3#optional!builtin<compat/typescript>::version=5.1.3&hash=5da071: The remote archive doesn't match the expected checksum
       - run: YARN_CHECKSUM_BEHAVIOR=ignore ~/.volta/bin/yarn install --immutable
-      - run: ~/.volta/bin/yarn test
         env:
           OPENAI_API_KEY: 'FAKE-OPENAI-API-KEY'
+      - run: ~/.volta/bin/yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,5 @@ jobs:
       #     YN0018: typescript@patch:typescript@npm%3A5.1.3#optional!builtin<compat/typescript>::version=5.1.3&hash=5da071: The remote archive doesn't match the expected checksum
       - run: YARN_CHECKSUM_BEHAVIOR=ignore ~/.volta/bin/yarn install --immutable
       - run: ~/.volta/bin/yarn test
+        env:
+          OPENAI_API_KEY: "FAKE-OPENAI-API-KEY"


### PR DESCRIPTION
Avoids the exception thrown in docs.tsx when building for next.js.