### PR TITLE
Minor link improvements and typo fixes

### DIFF
--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -9,7 +9,7 @@ This is a quickstart guide to [AI.JSX](https://ai-jsx.com).
 ## AI.JSX Hello World
 
 To use any of the AI.JSX examples (which use the OpenAI large language models), you first need to
-obtain an OpenAI API key from the [OpenAI API dashboard](https://beta.openai.com/docs/developer-quickstart/your-api-keys).
+obtain an OpenAI API key from the [OpenAI API dashboard](https://platform.openai.com/account/api-keys).
 
 For a quick "hello world" of AI.JSX in action, do this:
 

--- a/packages/docs/docs/guides/brand-new.md
+++ b/packages/docs/docs/guides/brand-new.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Guide for AI Newcomers
 
-Large Language Models (LLMs) are powerful tools, representing a paradigm shift in how we build and use software. Machines now have the ability to reason and understand natural language and code. We predict over the coming years, incumbents will be either remake themselves, or be disrupted by AI-native products and platforms.
+Large Language Models (LLMs) are powerful tools, representing a paradigm shift in how we build and use software. Machines now have the ability to reason, understand natural language, and code. We predict over the coming years, incumbents will be either remake themselves, or be disrupted by AI-native products and platforms.
 
 Just like in other types of programming, you can often get by with a simple solution until you need the heavier-duty tools. There are many techniques and concepts in AI programming, but you can make something useful without knowing them all.
 

--- a/packages/docs/docs/guides/prompting.md
+++ b/packages/docs/docs/guides/prompting.md
@@ -20,9 +20,9 @@ function App() {
 }
 ```
 
-`ChatCompletion` is preferred because all the most powerful models are chat-based, and [it's best to start with the most powerful models](./brand-new.md#recommended-dev-workflow).
+`ChatCompletion` is preferred to `Completion` because all the most powerful models are chat-based, and [it's best to start with the most powerful models](./brand-new.md#recommended-dev-workflow).
 
-To configure the output of `ChatCompletion`, use `ModelProps` (`packages/ai-jsx/src/core/completion.tsx`). This allows you to do things like making the model more creative or precise, telling the model how long a response you want back, etc. Combined with the natural language of your [prompt](./brand-new.md#prompt-engineering), this is how you control the model's output.
+To configure the output of `ChatCompletion`, use `ModelProps` (from [`ai-jsx/core/completion`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/core/completion.tsx)). This allows you to do things like making the model more creative or precise, telling the model how long a response you want back, etc. Combined with the natural language of your [prompt](./brand-new.md#prompt-engineering), this is how you control the model's output.
 
 ## What about non-chat models?
 
@@ -44,7 +44,7 @@ The problem is that the model is predicting that a question about one state is o
 
 ## Primitives to get you prompting faster
 
-We have included a small set of prompts that we found useful in [`packages/ai-jsx/src/batteries/prompts.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/batteries/prompts.tsx).
+We have included a small set of prompts that we found useful in [`ai-jsx/batteries/prompts`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/batteries/prompts.tsx).
 You can use them either as shortcuts, or as a starting point if you are new to prompting:
 
 ```tsx
@@ -87,4 +87,4 @@ function App() {
 ```
 
 Under the hood, this model will use a combination of prompting, validating the output, and asking them the model to retry
-if the validation fails (refer to [`packages/ai-jsx/src/batteries/constrained-output.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/batteries/constrained-output.tsx)).
+if the validation fails (refer to [`ai-jsx/batteries/constrained-output`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/batteries/constrained-output.tsx)).

--- a/packages/docs/docs/guides/rules-of-jsx.md
+++ b/packages/docs/docs/guides/rules-of-jsx.md
@@ -60,7 +60,7 @@ function* OrgData() {
 
 ## Component API
 
-Components take props as the first argument and ComponentContext (`packages/ai-jsx/src/index.ts`) as the second:
+Components take props as the first argument and ComponentContext ([`packages/ai-jsx/src/index.ts`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/index.ts)) as the second:
 
 ```tsx
 function MyComponent(props, componentContext) {}
@@ -82,7 +82,7 @@ function App() {
 /**
  * Ensure the model's response is JSON.
  */
-function ValidateJsonOutput({ children }, { render }): string {
+function JsonOutput({ children }, { render }): string {
   // highlight-next-line
   const rendered = await render(children);
   try {
@@ -195,12 +195,12 @@ Each instance of `CharacterGenerator` will use the context value set by its near
 
 See also:
 
-- API (`packages/ai-jsx/src/index.ts`)
-- Usage example (`packages/examples/src/context.tsx`)
+- API ([`packages/ai-jsx/src/core/core.ts`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/core/core.ts))
+- Usage example ([`packages/examples/src/context.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/examples/src/context.tsx))
 
 ## Handling Errors
 
-Use an Error Boundary (`packages/ai-jsx/src/core/error-boundary.ts`) to provide fallback values when a component throws:
+Use an Error Boundary ([`packages/ai-jsx/src/core/error-boundary.ts`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/core/error-boundary.ts)) to provide fallback values when a component throws:
 
 ```tsx
 <ErrorBoundary fallback={'✅ Error was handled'}>
@@ -208,7 +208,7 @@ Use an Error Boundary (`packages/ai-jsx/src/core/error-boundary.ts`) to provide 
 </ErrorBoundary>
 ```
 
-Error boundary example (`packages/examples/src/errors.tsx`).
+Error boundary example ([`packages/examples/src/errors.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/examples/src/errors.tsx)).
 
 ## Memoization
 
@@ -249,7 +249,7 @@ const catName = memo(
 
 Now, `catName` will result in a single model call, and its value will be reused everywhere that component appears in the tree.
 
-- API (`packages/ai-jsx/src/core/memoize.tsx`)
+- API ([`packages/ai-jsx/src/core/memoize.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/core/memoize.tsx))
 
 # See Also
 

--- a/packages/docs/docs/tutorial/part4.md
+++ b/packages/docs/docs/tutorial/part4.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Tutorial Part 4 - Document Q&A
 
 One of the most powerful capabilities of Large Language Models is the ability to
-answer questions about the contents of a set of documents. AI. JSX provides a powerful
+answer questions about the contents of a set of documents. AI.JSX provides a powerful
 component called `<DocsQA>` that can answer a question about a corpus of documents
 using the LLM.
 


### PR DESCRIPTION
Some minor typo and links were updated.

On `ai-jsx` package module links: I've tried to turn into their "import" format + link to actual Github file:
- `packages/ai-jsx/src/core/xyz.tsx` -> `[ai-jsx/core/xyz](https://github.com/fixie-ai/ai-jsx/blob/main/packages/ai-jsx/src/core/xyx.tsx)`

I did not change them where it didn't make that much sense (e.g. for `packages/ai-jsx/src/index.ts`).






