### PR TITLE
Fix env var logic

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/lib/util.test.ts
+++ b/packages/ai-jsx/src/lib/util.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals';
+import { getEnvVar } from "./util";
+
+process.env.EXISTS = 'exists'
+process.env.REACT_APP_ONLY = 'react-value'
+
+test('env var exists under original name', () => {
+  expect(getEnvVar('EXISTS')).toEqual('exists')
+})
+
+test('env var exists under react app name', () => {
+  expect(getEnvVar('ONLY')).toEqual('react-value')
+});
+
+test('env var does not exist', () => {
+  expect(() => getEnvVar('DOES_NOT_EXIST')).toThrowError(/Please specify env var 'DOES_NOT_EXIST' or 'REACT_APP_DOES_NOT_EXIST'./)
+});
+
+test('env var does not exist and shouldThrow=false', () => {
+  expect(getEnvVar('DOES_NOT_EXIST', false)).toBeUndefined();
+});

--- a/packages/ai-jsx/src/lib/util.test.ts
+++ b/packages/ai-jsx/src/lib/util.test.ts
@@ -1,19 +1,21 @@
 import { expect, test } from '@jest/globals';
-import { getEnvVar } from "./util";
+import { getEnvVar } from './util';
 
-process.env.EXISTS = 'exists'
-process.env.REACT_APP_ONLY = 'react-value'
+process.env.EXISTS = 'exists';
+process.env.REACT_APP_ONLY = 'react-value';
 
 test('env var exists under original name', () => {
-  expect(getEnvVar('EXISTS')).toEqual('exists')
-})
+  expect(getEnvVar('EXISTS')).toEqual('exists');
+});
 
 test('env var exists under react app name', () => {
-  expect(getEnvVar('ONLY')).toEqual('react-value')
+  expect(getEnvVar('ONLY')).toEqual('react-value');
 });
 
 test('env var does not exist', () => {
-  expect(() => getEnvVar('DOES_NOT_EXIST')).toThrowError(/Please specify env var 'DOES_NOT_EXIST' or 'REACT_APP_DOES_NOT_EXIST'./)
+  expect(() => getEnvVar('DOES_NOT_EXIST')).toThrowError(
+    /Please specify env var 'DOES_NOT_EXIST' or 'REACT_APP_DOES_NOT_EXIST'./
+  );
 });
 
 test('env var does not exist and shouldThrow=false', () => {

--- a/packages/ai-jsx/src/lib/util.ts
+++ b/packages/ai-jsx/src/lib/util.ts
@@ -1,15 +1,12 @@
 /** @hidden */
 export function getEnvVar(name: string, shouldThrow: boolean = true) {
+  const reactAppName = `REACT_APP_${name}`;
   // We actually want the nullish coalescing behavior in this case,
   // because we want to treat '' as undefined.
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return getEnvVarByName(name, shouldThrow) || getEnvVarByName(`REACT_APP_${name}`, shouldThrow);
-}
-
-function getEnvVarByName(name: string, shouldThrow: boolean) {
-  const value = process.env[name];
-  if (!value && shouldThrow) {
-    throw new Error(`Please specify env var "${name}".`);
+  const result = process.env[name] || process.env[reactAppName];
+  if (result === undefined && shouldThrow) {
+    throw new Error(`Please specify env var '${name}' or '${reactAppName}'.`);
   }
-  return value;
+  return result;
 }


### PR DESCRIPTION
Previously, the `shouldThrow` logic was too aggressive, and the env var lookup would throw an error if `FOO` didn't exist, even if `REACT_APP_FOO` did.