### PR TITLE
<UseTools /> match syntax with OpenAI functions

### DIFF
--- a/docs/internal/aspirational-readme.md
+++ b/docs/internal/aspirational-readme.md
@@ -876,7 +876,7 @@ async function turnLightsOff() {}
 /**
  * Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
  */
-async function activateScene({sceneName}: {sceneName: string}) {}
+async function activateScene({ sceneName }: { sceneName: string }) {}
 
 import z from 'zod';
 const tools: Record<string, Tool> = {
@@ -894,8 +894,8 @@ const tools: Record<string, Tool> = {
     description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
     parameters: {
       sceneName: {
-        description: "The scene to activate the lighting in.",
-        type: "string",
+        description: 'The scene to activate the lighting in.',
+        type: 'string',
         required: true,
       },
     },

--- a/docs/internal/aspirational-readme.md
+++ b/docs/internal/aspirational-readme.md
@@ -876,23 +876,29 @@ async function turnLightsOff() {}
 /**
  * Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
  */
-async function activateScene(sceneName: string) {}
+async function activateScene({sceneName}: {sceneName: string}) {}
 
 import z from 'zod';
 const tools: Record<string, Tool> = {
   turnLightsOn: {
     description: "Turn the lights on in the user's home",
-    parameters: z.tuple([]),
+    parameters: {},
     func: turnLightsOn,
   },
   turnLightsOff: {
     description: "Turn the lights off in the user's home",
-    parameters: z.tuple([]),
+    parameters: {},
     func: turnLightsOff,
   },
   activateScene: {
     description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
-    parameters: z.tuple([z.string()]),
+    parameters: {
+      sceneName: {
+        description: "The scene to activate the lighting in.",
+        type: "string",
+        required: true,
+      },
+    },
     func: activateScene,
   },
 };
@@ -910,7 +916,7 @@ interface Tool {
   /**
    * A function implementing the tool.
    */
-  func: (...args: any[]) => any;
+  func: (args: Record<string, any>) => any;
 }
 
 // Provide the tools to the agent

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -6,7 +6,7 @@
 
 import { ChatCompletion, FunctionParameter, SystemMessage, UserMessage } from '../core/completion.js';
 import { Node, RenderContext } from '../index.js';
-import z, { ZodTypeAny } from 'zod';
+import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
 

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { ChatCompletion, SystemMessage, UserMessage } from '../core/completion.js';
+import { ChatCompletion, FunctionParameter, SystemMessage, UserMessage } from '../core/completion.js';
 import { Node, RenderContext } from '../index.js';
 import z, { ZodTypeAny } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -12,7 +12,7 @@ import { AIJSXError, ErrorCode } from '../core/errors.js';
 
 const toolChoiceSchema = z.object({
   nameOfTool: z.string(),
-  parameters: z.array(z.any()),
+  parameters: z.record(z.string(), z.any()),
   responseToUser: z.string(),
 });
 export type ToolChoice = z.infer<typeof toolChoiceSchema> | null;
@@ -24,7 +24,7 @@ function ChooseTools(props: Pick<UseToolsProps, 'tools' | 'userData' | 'query'>)
         You are an expert agent who knows how to use tools. You can use the following tools:
         {Object.entries(props.tools).map(([toolName, tool]) => (
           <>
-            {toolName}: Description: {tool.description}. Schema: {JSON.stringify(zodToJsonSchema(tool.parameters))}.
+            {toolName}: Description: {tool.description}. Schema: {JSON.stringify(tool.parameters)}.
           </>
         ))}
         The user will ask you a question. Pick the tool that best addresses what they're looking for. Which tool do you
@@ -72,7 +72,7 @@ async function InvokeTool(
     );
   }
   const tool = props.tools[toolChoiceResult.nameOfTool];
-  const toolResult = await tool.func(...toolChoiceResult.parameters);
+  const toolResult = await tool.func(toolChoiceResult.parameters);
 
   // TDOO: Restore this once we have the logger attached to the render context.
   // log.info({ toolChoice: toolChoiceResult }, 'Invoking tool');
@@ -99,9 +99,9 @@ export interface Tool {
   description: string;
 
   /**
-   * A Zod schema describing the parameters the tool takes.
+   * A map of parameter names to their description and type.
    */
-  parameters: ZodTypeAny;
+  parameters: Record<string, FunctionParameter>;
 
   /**
    * A function to invoke the tool.
@@ -147,23 +147,29 @@ export interface UseToolsProps {
  *  async function turnLightsOn() { ... Code to turn lights on ... }
  *  async function turnLightsOff() { ... Code to turn lights off ... }
  *  // Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
- *  async function activeScene(sceneName: string) { ... Code to activate a scene ... }
+ *  async function activeScene({sceneName}: {sceneName: string}) { ... Code to activate a scene ... }
  *
  *  import z from 'zod';
  *  const tools: Record<string, Tool> = {
  *    turnLightsOn: {
  *      description: "Turn the lights on in the user's home",
- *      parameters: z.tuple([]),
+ *      parameters: {},
  *      func: turnLightsOn,
  *    },
  *    turnLightsOff: {
  *      description: "Turn the lights off in the user's home",
- *      parameters: z.tuple([]),
+ *      parameters: {},
  *      func: turnLightsOff,
  *    },
  *    activeScene: {
  *      description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
- *      parameters: z.string(),
+ *      parameters: {
+ *        sceneName: {
+ *          description: "The scene to activate the lighting in.",
+ *          type: "string",
+ *          required: true,
+ *        },
+ *      },
  *      func: activeScene,
  *    },
  *  };

--- a/packages/docs/docs/guides/brand-new.md
+++ b/packages/docs/docs/guides/brand-new.md
@@ -97,14 +97,20 @@ In AI.JSX, this looks like:
 /**
  * Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
  */
-async function activateScene(sceneName: string) {}
+async function activateScene({sceneName}: {sceneName: string}) {}
 
 // Describe to the LLM what's available
 import z from 'zod';
 const tools: Record<string, Tool> = {
   activateScene: {
     description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
-    parameters: z.tuple([z.string()]),
+    parameters: parameters: {
+      sceneName: {
+        description: "The scene to activate the lighting in.",
+        type: "string",
+        required: true,
+      },
+    },
     func: activateScene,
   },
 };

--- a/packages/docs/docs/tutorial/part7-tools.md
+++ b/packages/docs/docs/tutorial/part7-tools.md
@@ -22,8 +22,8 @@ const tools = {
     description: 'Check the price of a stock.',
     parameters: {
       symbol: {
-        description: "The symbol of the stock to get price for.",
-        type: "string",
+        description: 'The symbol of the stock to get price for.',
+        type: 'string',
         required: true,
       },
     },
@@ -33,8 +33,8 @@ const tools = {
     description: 'Return historical prices for a stock.',
     parameters: {
       symbol: {
-        description: "The symbol of the stock to get price for.",
-        type: "string",
+        description: 'The symbol of the stock to get price for.',
+        type: 'string',
         required: true,
       },
     },
@@ -73,7 +73,7 @@ return a static string. Here's the `checkStockPrice` function:
 ```tsx filename="packages/tutorial/src/tools.tsx"
 import yahooFinance from 'yahoo-finance2';
 
-async function checkStockPrice({symbol}: {symbol: string}) {
+async function checkStockPrice({ symbol }: { symbol: string }) {
   const quote = await yahooFinance.quote(symbol);
   return quote.regularMarketPrice ?? 'Unknown';
 }
@@ -97,7 +97,7 @@ fetches a list of prices and generates a graph:
 ```tsx filename="packages/tutorial/src/tools.tsx"
 import asciichart from 'asciichart';
 
-async function getHistoricalPrices({symbol}: {symbol: string}) {
+async function getHistoricalPrices({ symbol }: { symbol: string }) {
   const endTime = new Date();
   const startTime = new Date();
   startTime.setMonth(endTime.getMonth() - 1);

--- a/packages/docs/docs/tutorial/part7-tools.md
+++ b/packages/docs/docs/tutorial/part7-tools.md
@@ -20,12 +20,24 @@ invoked to perform some external action.
 const tools = {
   checkStockPrice: {
     description: 'Check the price of a stock.',
-    parameters: z.string(),
+    parameters: {
+      symbol: {
+        description: "The symbol of the stock to get price for.",
+        type: "string",
+        required: true,
+      },
+    },
     func: checkStockPrice,
   },
   getHistoricalPrices: {
     description: 'Return historical prices for a stock.',
-    parameters: z.string(),
+    parameters: {
+      symbol: {
+        description: "The symbol of the stock to get price for.",
+        type: "string",
+        required: true,
+      },
+    },
     func: getHistoricalPrices,
   },
 };
@@ -61,7 +73,7 @@ return a static string. Here's the `checkStockPrice` function:
 ```tsx filename="packages/tutorial/src/tools.tsx"
 import yahooFinance from 'yahoo-finance2';
 
-async function checkStockPrice(symbol: string) {
+async function checkStockPrice({symbol}: {symbol: string}) {
   const quote = await yahooFinance.quote(symbol);
   return quote.regularMarketPrice ?? 'Unknown';
 }
@@ -85,7 +97,7 @@ fetches a list of prices and generates a graph:
 ```tsx filename="packages/tutorial/src/tools.tsx"
 import asciichart from 'asciichart';
 
-async function getHistoricalPrices(symbol: string) {
+async function getHistoricalPrices({symbol}: {symbol: string}) {
   const endTime = new Date();
   const startTime = new Date();
   startTime.setMonth(endTime.getMonth() - 1);

--- a/packages/examples/src/bakeoff/health-agent/README.md
+++ b/packages/examples/src/bakeoff/health-agent/README.md
@@ -100,14 +100,14 @@ const tools: Record<string, Tool> = {
     // Tell the user how to
     parameters: {
       xLabels: {
-        description: "A comma separated list of x-axis labels.",
-        type: "string",
+        description: 'A comma separated list of x-axis labels.',
+        type: 'string',
         required: true,
       },
       yValues: {
-        description: "A comma separated list of y-axis values.",
-        type: "string",
-        required: "bool", 
+        description: 'A comma separated list of y-axis values.',
+        type: 'string',
+        required: 'bool',
       },
     },
     func: generateChartFromTimeSeries,
@@ -116,8 +116,8 @@ const tools: Record<string, Tool> = {
     description: 'Generate a histogram from a list of values.',
     parameters: {
       values: {
-        description: "A comma separated list of x-axis labels.",
-        type: "string",
+        description: 'A comma separated list of x-axis labels.',
+        type: 'string',
         required: true,
       },
     },

--- a/packages/examples/src/bakeoff/health-agent/README.md
+++ b/packages/examples/src/bakeoff/health-agent/README.md
@@ -98,17 +98,29 @@ const tools: Record<string, Tool> = {
   generateChartFromTimeSeries: {
     description: 'Generate a bar chart from a time series, given x labels and y values.',
     // Tell the user how to
-    parameters: z.object({
-      xLabels: z.array(z.string()),
-      yValues: z.array(z.number()),
-    }),
+    parameters: {
+      xLabels: {
+        description: "A comma separated list of x-axis labels.",
+        type: "string",
+        required: true,
+      },
+      yValues: {
+        description: "A comma separated list of y-axis values.",
+        type: "string",
+        required: "bool", 
+      },
+    },
     func: generateChartFromTimeSeries,
   },
   generateHistogram: {
     description: 'Generate a histogram from a list of values.',
-    parameters: z.object({
-      values: z.array(z.number()),
-    }),
+    parameters: {
+      values: {
+        description: "A comma separated list of x-axis labels.",
+        type: "string",
+        required: true,
+      },
+    },
     func: generateHistogram,
   },
 };

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -3,12 +3,24 @@ import { z } from 'zod';
 import { UseTools, Tool } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
 
+
+function evaluate({ expression }: { expression: string }) {
+  return math.evaluate(expression);
+}
+
+
 function App({ query }: { query: string }) {
   const tools: Record<string, Tool> = {
     evaluate_expression: {
       description: 'Evaluates a mathematical expression',
-      parameters: z.tuple([z.string()]),
-      func: math.evaluate,
+      parameters: {
+        expression: {
+          description: 'The mathematical expression to evaluate',
+          type: 'string',
+          required: true,
+        },
+      },
+      func: evaluate,
     },
   };
   return <UseTools tools={tools} query={query} fallback="Failed to evaluate the mathematical expression" />;

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -1,5 +1,4 @@
 import * as math from 'mathjs';
-import { z } from 'zod';
 import { UseTools, Tool } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
 

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -3,11 +3,9 @@ import { z } from 'zod';
 import { UseTools, Tool } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
 
-
 function evaluate({ expression }: { expression: string }) {
   return math.evaluate(expression);
 }
-
 
 function App({ query }: { query: string }) {
   const tools: Record<string, Tool> = {

--- a/packages/tutorial/src/tools.tsx
+++ b/packages/tutorial/src/tools.tsx
@@ -8,12 +8,12 @@ import enquirer from 'enquirer';
 const { prompt } = enquirer;
 
 function StockAgent(props: { query: string }) {
-  async function checkStockPrice(symbol: string) {
+  async function checkStockPrice({symbol}: {symbol: string}) {
     const quote = await yahooFinance.quote(symbol);
     return quote.regularMarketPrice ?? 'Unknown';
   }
 
-  async function getHistoricalPrices(symbol: string) {
+  async function getHistoricalPrices({symbol}: {symbol: string}) {
     const endTime = new Date();
     const startTime = new Date();
     startTime.setMonth(endTime.getMonth() - 1);
@@ -30,12 +30,24 @@ function StockAgent(props: { query: string }) {
   const tools = {
     checkStockPrice: {
       description: 'Check the price of a stock.',
-      parameters: z.string(),
+      parameters: {
+        symbol: {
+          description: 'The stock symbol to check the price of.',
+          type: 'string',
+          required: true,
+        },
+      },
       func: checkStockPrice,
     },
     getHistoricalPrices: {
       description: 'Return historical prices for a stock.',
-      parameters: z.string(),
+      parameters: {
+        symbol: {
+          description: 'The stock symbol to get historical prices for.',
+          type: 'string',
+          required: true,
+        },
+      },
       func: getHistoricalPrices,
     },
   };

--- a/packages/tutorial/src/tools.tsx
+++ b/packages/tutorial/src/tools.tsx
@@ -1,6 +1,5 @@
 import * as AI from 'ai-jsx';
 import { UseTools } from 'ai-jsx/batteries/use-tools';
-import z from 'zod';
 import yahooFinance from 'yahoo-finance2';
 import asciichart from 'asciichart';
 import enquirer from 'enquirer';

--- a/packages/tutorial/src/tools.tsx
+++ b/packages/tutorial/src/tools.tsx
@@ -8,12 +8,12 @@ import enquirer from 'enquirer';
 const { prompt } = enquirer;
 
 function StockAgent(props: { query: string }) {
-  async function checkStockPrice({symbol}: {symbol: string}) {
+  async function checkStockPrice({ symbol }: { symbol: string }) {
     const quote = await yahooFinance.quote(symbol);
     return quote.regularMarketPrice ?? 'Unknown';
   }
 
-  async function getHistoricalPrices({symbol}: {symbol: string}) {
+  async function getHistoricalPrices({ symbol }: { symbol: string }) {
     const endTime = new Date();
     const startTime = new Date();
     startTime.setMonth(endTime.getMonth() - 1);


### PR DESCRIPTION
This PR doesn't connect `<UseTools />` to OpenAI's function-call yet, but only changes the syntax of _parameter definitions_ in `<UseTools />` to match how OpenAI expects its function parameters. The syntax changes are: 1. Each parameter is named, 2. Each parameter has a short description to go with it.

As a side effect, the stock demo now automatically passes the symbol of a stock (e.g. TSLA) to the target functions even when it's asked "How much is Elon Musk's biggest company's stock worth right now?"
```
➜  ai-jsx git:(hessam/use-tools-match-syntax-with-openai-functions) yarn workspace tutorial run part7                                     
✔ Ask me a question about a stock:  · How much is Elon Musk's biggest company's stock worth right now?

Fetching crumb and cookies from https://finance.yahoo.com/quote/AAPL...
Success.  Cookie expires on Wed Jun 26 2024 17:29:09 GMT-0700 (Pacific Daylight Time)
The current stock price of TSLA, Elon Musk's biggest company, is 248.829.
```

A follow up PR will switch the implementation to rely on OpenAI functions for implementation if a function-call-enabled-llm is activated in the context (i.e. gpt-4-0613 and gpt-3.5-turbo-0613).