### PR TITLE
Pinecone DocsQA example with LangChainCorpus

### DIFF
--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -706,8 +706,7 @@ async function searchVectorStore<ChunkMetadata extends Jsonifiable = Jsonifiable
   params?: { limit?: number; score_threshold?: number }
 ): Promise<ScoredChunk<ChunkMetadata>[]> {
   const k = params?.limit ?? defaultLangchainChunkLimit;
-  delete params?.limit;
-  const scoredLcDocs = await vectorStore.similaritySearchWithScore(query, k, params);
+  const scoredLcDocs = await vectorStore.similaritySearchWithScore(query, k, _.omit(params, 'limit'));
   return scoredLcDocs.map((lcDocAndScore) => {
     const lcDoc = lcDocAndScore[0];
     return {

--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -705,11 +705,9 @@ async function searchVectorStore<ChunkMetadata extends Jsonifiable = Jsonifiable
   query: string,
   params?: { limit?: number; score_threshold?: number }
 ): Promise<ScoredChunk<ChunkMetadata>[]> {
-  const scoredLcDocs = await vectorStore.similaritySearchWithScore(
-    query,
-    params?.limit ?? defaultLangchainChunkLimit,
-    params
-  );
+  const k = params?.limit ?? defaultLangchainChunkLimit;
+  delete params?.limit;
+  const scoredLcDocs = await vectorStore.similaritySearchWithScore(query, k, params);
   return scoredLcDocs.map((lcDocAndScore) => {
     const lcDoc = lcDocAndScore[0];
     return {

--- a/packages/tutorial/package.json
+++ b/packages/tutorial/package.json
@@ -25,6 +25,7 @@
     "part2": "yarn build && node dist/inline.js",
     "part3": "yarn build && node dist/constrained-output.js",
     "part4": "yarn build && node dist/docsqa.js",
+    "part4_pinecone": "yarn build && node dist/docsqa_pinecone.js",
     "part6": "yarn build && node dist/router.js",
     "part7": "yarn build && node dist/tools.js",
     "view-logs": "cat ai-jsx.log | pino-pretty",
@@ -34,10 +35,12 @@
     "build": "yarn run typecheck"
   },
   "dependencies": {
+    "@pinecone-database/pinecone": "^0.1.6",
     "ai-jsx": "0.5.6",
     "asciichart": "^1.5.25",
     "axios": "^1.4.0",
     "enquirer": "^2.3.6",
+    "langchain": "^0.0.81",
     "node-fetch": "^3.3.1",
     "pino": "^8.14.1",
     "pino-pretty": "^10.0.0",

--- a/packages/tutorial/src/docsqa_pinecone.tsx
+++ b/packages/tutorial/src/docsqa_pinecone.tsx
@@ -1,3 +1,18 @@
+/**
+ * This example shows how to use the PineconeStore with a LangChainCorpus for DocsQA.
+ * This is a more advanced version of `docsqa.tsx`, which uses a {@link LocalCorpus} so
+ * make sure to check that out first.
+ *
+ * Since a Pinecone database is used, you need to make sure you have a Pinecone account,
+ * and an index created before running it. Check out the `pineconeConfig` object below which
+ * uses environment variables to store the Pinecone API key, environment, and index name.
+ *
+ * Once you have all of that set up, you can run this example with:
+ * ```bash
+ *    yarn workspace tutorial run part4_pinecone
+ * ```
+ * @packageDocumentation
+ */
 import { DocsQA, ScoredChunk, LangchainCorpus } from 'ai-jsx/batteries/docs';
 import { showInspector } from 'ai-jsx/core/inspector';
 
@@ -9,11 +24,10 @@ import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
 import { TextLoader } from 'langchain/document_loaders/fs/text';
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 
-const settings = {
+const pineconeConfig = {
   apiKey: process.env.PINECONE_API_KEY!,
   environment: process.env.PINECONE_ENVIRONMENT!,
   index: process.env.PINECONE_INDEX!,
-  openaiApiKey: process.env.OPENAI_API_KEY!,
   namespace: 'ai-jsx-tutorial-part4',
 };
 
@@ -21,24 +35,31 @@ function GetChunk({ doc }: { doc: ScoredChunk }) {
   return doc.chunk.content;
 }
 
+/**
+ * Creates a PineconeStore from the ai-jsx docs.
+ * If the namespace exists however, it will not re-index the documents.
+ *
+ * Note: make sure to set the environment variables for the Pinecone API key,
+ * environment, and index name first.
+ *
+ * @returns a PineconeStore
+ */
 async function getVectorStore(): Promise<VectorStore> {
   const client = new PineconeClient();
   await client.init({
-    apiKey: settings.apiKey,
-    environment: settings.environment,
+    apiKey: pineconeConfig.apiKey,
+    environment: pineconeConfig.environment,
   });
-  const pineconeIndex = client.Index(settings.index);
-  // await pineconeIndex.delete1({ deleteAll: true, namespace: settings.namespace });
+  const pineconeIndex = client.Index(pineconeConfig.index);
 
   const res = await pineconeIndex.describeIndexStats({ describeIndexStatsRequest: { filter: {} } });
-  console.log('res', res);
 
   const embedder = new OpenAIEmbeddings({
     modelName: 'text-embedding-ada-002',
-    openAIApiKey: settings.openaiApiKey,
+    openAIApiKey: process.env.OPENAI_API_KEY!,
   });
 
-  if (res.namespaces === undefined || !(settings.namespace in res.namespaces)) {
+  if (res.namespaces === undefined || !(pineconeConfig.namespace in res.namespaces)) {
     console.log('Namespace does not exist. Creating and indexing documents ...');
 
     // For this example, we will use the ai-jsx docs.
@@ -55,7 +76,7 @@ async function getVectorStore(): Promise<VectorStore> {
 
     const vectorStore: VectorStore = await PineconeStore.fromDocuments(docs, embedder, {
       pineconeIndex,
-      namespace: settings.namespace,
+      namespace: pineconeConfig.namespace,
     });
     return vectorStore;
   }
@@ -63,7 +84,7 @@ async function getVectorStore(): Promise<VectorStore> {
   console.log("Namespace exists. Loading it's index ...");
   const vectorStore: VectorStore = await PineconeStore.fromExistingIndex(embedder, {
     pineconeIndex,
-    namespace: settings.namespace,
+    namespace: pineconeConfig.namespace,
   });
   return vectorStore;
 }

--- a/packages/tutorial/src/docsqa_pinecone.tsx
+++ b/packages/tutorial/src/docsqa_pinecone.tsx
@@ -74,7 +74,7 @@ async function getVectorStore(): Promise<VectorStore> {
     });
     const docs = await loader.loadAndSplit(splitter);
 
-    const vectorStore: VectorStore = await PineconeStore.fromDocuments(docs, embedder, {
+    const vectorStore = await PineconeStore.fromDocuments(docs, embedder, {
       pineconeIndex,
       namespace: pineconeConfig.namespace,
     });
@@ -82,7 +82,7 @@ async function getVectorStore(): Promise<VectorStore> {
   }
 
   console.log("Namespace exists. Loading it's index ...");
-  const vectorStore: VectorStore = await PineconeStore.fromExistingIndex(embedder, {
+  const vectorStore = await PineconeStore.fromExistingIndex(embedder, {
     pineconeIndex,
     namespace: pineconeConfig.namespace,
   });

--- a/packages/tutorial/src/docsqa_pinecone.tsx
+++ b/packages/tutorial/src/docsqa_pinecone.tsx
@@ -1,0 +1,88 @@
+import { DocsQA, ScoredChunk, LangchainCorpus } from 'ai-jsx/batteries/docs';
+import { showInspector } from 'ai-jsx/core/inspector';
+
+import { PineconeClient } from '@pinecone-database/pinecone';
+import { OpenAIEmbeddings } from 'langchain/embeddings/openai';
+import { PineconeStore } from 'langchain/vectorstores/pinecone';
+import { VectorStore } from 'langchain/vectorstores';
+import { DirectoryLoader } from 'langchain/document_loaders/fs/directory';
+import { TextLoader } from 'langchain/document_loaders/fs/text';
+import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
+
+const settings = {
+  apiKey: process.env.PINECONE_API_KEY!,
+  environment: process.env.PINECONE_ENVIRONMENT!,
+  index: process.env.PINECONE_INDEX!,
+  openaiApiKey: process.env.OPENAI_API_KEY!,
+  namespace: 'ai-jsx-tutorial-part4',
+};
+
+function GetChunk({ doc }: { doc: ScoredChunk }) {
+  return doc.chunk.content;
+}
+
+async function getVectorStore(): Promise<VectorStore> {
+  const client = new PineconeClient();
+  await client.init({
+    apiKey: settings.apiKey,
+    environment: settings.environment,
+  });
+  const pineconeIndex = client.Index(settings.index);
+  // await pineconeIndex.delete1({ deleteAll: true, namespace: settings.namespace });
+
+  const res = await pineconeIndex.describeIndexStats({ describeIndexStatsRequest: { filter: {} } });
+  console.log('res', res);
+
+  const embedder = new OpenAIEmbeddings({
+    modelName: 'text-embedding-ada-002',
+    openAIApiKey: settings.openaiApiKey,
+  });
+
+  if (res.namespaces === undefined || !(settings.namespace in res.namespaces)) {
+    console.log('Namespace does not exist. Creating and indexing documents ...');
+
+    // For this example, we will use the ai-jsx docs.
+    const loader = new DirectoryLoader('../../packages/docs/docs/', {
+      '.md': (path) => new TextLoader(path),
+    });
+
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 1000,
+      chunkOverlap: 100,
+      separators: ['\n## ', '\n###', '\n\n', '\n', ' '],
+    });
+    const docs = await loader.loadAndSplit(splitter);
+
+    const vectorStore: VectorStore = await PineconeStore.fromDocuments(docs, embedder, {
+      pineconeIndex,
+      namespace: settings.namespace,
+    });
+    return vectorStore;
+  }
+
+  console.log("Namespace exists. Loading it's index ...");
+  const vectorStore: VectorStore = await PineconeStore.fromExistingIndex(embedder, {
+    pineconeIndex,
+    namespace: settings.namespace,
+  });
+  return vectorStore;
+}
+
+const corpus = new LangchainCorpus(await getVectorStore());
+
+function App() {
+  return (
+    <>
+      <DocsQA
+        question="What is the advantage of using JIT UI?"
+        corpus={corpus}
+        chunkLimit={4}
+        chunkFormatter={GetChunk}
+      />
+      {'\n\n'}
+      <DocsQA question="How can I contribute to AI.JSX?" corpus={corpus} chunkLimit={4} chunkFormatter={GetChunk} />
+    </>
+  );
+}
+
+showInspector(<App />);

--- a/packages/tutorial/src/docsqa_pinecone.tsx
+++ b/packages/tutorial/src/docsqa_pinecone.tsx
@@ -1,7 +1,7 @@
 /**
  * This example shows how to use the PineconeStore with a LangChainCorpus for DocsQA.
- * This is a more advanced version of `docsqa.tsx`, which uses a {@link LocalCorpus} so
- * make sure to check that out first.
+ * This is a more advanced version of `docsqa.tsx`, which uses a {@link LocalCorpus},
+ * so make sure to check that out first.
  *
  * Since a Pinecone database is used, you need to make sure you have a Pinecone account,
  * and an index created before running it. Check out the `pineconeConfig` object below which
@@ -37,7 +37,7 @@ function GetChunk({ doc }: { doc: ScoredChunk }) {
 
 /**
  * Creates a PineconeStore from the ai-jsx docs.
- * If the namespace exists however, it will not re-index the documents.
+ * If the namespace exists, it will not re-index the documents for efficiency.
  *
  * Note: make sure to set the environment variables for the Pinecone API key,
  * environment, and index name first.
@@ -81,7 +81,7 @@ async function getVectorStore(): Promise<VectorStore> {
     return vectorStore;
   }
 
-  console.log("Namespace exists. Loading it's index ...");
+  console.log('Namespace exists. Loading its index ...');
   const vectorStore = await PineconeStore.fromExistingIndex(embedder, {
     pineconeIndex,
     namespace: pineconeConfig.namespace,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5356,6 +5356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pinecone-database/pinecone@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "@pinecone-database/pinecone@npm:0.1.6"
+  dependencies:
+    cross-fetch: ^3.1.5
+  checksum: 26f1a40b0353c3dabd9f8824ac0db4d9089fd8ea9e92f01f7c6650e7a21c7e25415bed396010b013d0fe1956c88d57fa1f01f3fb3fc64f06708dce518517ea38
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -22572,6 +22581,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tutorial@workspace:packages/tutorial"
   dependencies:
+    "@pinecone-database/pinecone": ^0.1.6
     "@tsconfig/node18": ^2.0.1
     "@types/asciichart": ^1.5.6
     "@types/lodash": ^4.14.195
@@ -22587,6 +22597,7 @@ __metadata:
     enquirer: ^2.3.6
     eslint: ^8.40.0
     eslint-config-nth: ^2.0.1
+    langchain: ^0.0.81
     node-fetch: ^3.3.1
     pino: ^8.14.1
     pino-pretty: ^10.0.0


### PR DESCRIPTION
This PR adds an example of using a Pincone database through a LangChainCorpus to the tutorials.