### PR TITLE
Add support for append-only text streaming

### DIFF
--- a/packages/ai-jsx/src/batteries/logging-integrations.tsx
+++ b/packages/ai-jsx/src/batteries/logging-integrations.tsx
@@ -75,9 +75,9 @@ export function WeightsAndBiasesTracer(
 
   return AI.withContext(
     <>{children}</>,
-    wrapRender((r) => (renderContext, renderable, shouldStop) => {
+    wrapRender((r) => (renderContext, renderable, shouldStop, appendOnly) => {
       if (!AI.isElement(renderable)) {
-        return r(renderContext, renderable, shouldStop);
+        return r(renderContext, renderable, shouldStop, appendOnly);
       }
 
       const newSpan = {
@@ -105,7 +105,7 @@ export function WeightsAndBiasesTracer(
         async function* gen() {
           const currentSpan = currentSpanStorage.getStore();
           try {
-            const result = yield* r(renderContext, renderable, shouldStop);
+            const result = yield* r(renderContext, renderable, shouldStop, appendOnly);
             if (currentSpan) {
               currentSpan.status_code = StatusCode.SUCCESS;
             }

--- a/packages/ai-jsx/src/core/core.ts
+++ b/packages/ai-jsx/src/core/core.ts
@@ -316,20 +316,20 @@ async function* renderStream(
     });
 
     const currentValue = () => {
-      if (!appendOnly) {
-        return inProgressRenders.flatMap((r) => r.currentValue);
-      }
-
-      let currentValue = [] as PartiallyRendered[];
-      for (const inProgressRender of inProgressRenders) {
-        currentValue = currentValue.concat(inProgressRender.currentValue);
-        if (inProgressRender.currentPromise !== null) {
-          // This node is still rendering, so we can't include any ones beyond it.
-          break;
+      if (appendOnly) {
+        let currentValue = [] as PartiallyRendered[];
+        for (const inProgressRender of inProgressRenders) {
+          currentValue = currentValue.concat(inProgressRender.currentValue);
+          if (inProgressRender.currentPromise !== null) {
+            // This node is still rendering, so we can't include any ones beyond it.
+            break;
+          }
         }
+
+        return currentValue;
       }
 
-      return currentValue;
+      return inProgressRenders.flatMap((r) => r.currentValue);
     };
     const remainingPromises = () => inProgressRenders.flatMap((r) => (r.currentPromise ? [r.currentPromise] : []));
 

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -222,8 +222,8 @@ async function checkOpenAIResponse<M extends OpenAIMethod>(response: Response, l
 export async function* OpenAICompletionModel(
   props: ModelPropsWithChildren & { model: ValidCompletionModel; logitBias?: Record<string, number> },
   { render, getContext, logger }: AI.ComponentContext
-) {
-  yield '';
+): AI.RenderableStream {
+  yield AI.AppendOnlyStream;
 
   const openai = getContext(openAiClientContext);
   const completionRequest = {
@@ -248,13 +248,13 @@ export async function* OpenAICompletionModel(
 
   for await (const event of openAiEventsToJson<CreateCompletionResponse>(responseIterator)) {
     logger.trace({ event }, 'Got createCompletion event');
+    yield event.choices[0].text;
     resultSoFar += event.choices[0].text;
-    yield resultSoFar;
   }
 
   logger.debug({ completion: resultSoFar }, 'Finished createCompletion');
 
-  return resultSoFar;
+  return AI.AppendOnlyStream;
 }
 
 /**
@@ -267,7 +267,7 @@ export async function* OpenAIChatModel(
     functionDefinitions?: FunctionDefinition[];
   },
   { render, getContext, logger }: AI.ComponentContext
-) {
+): AI.RenderableStream {
   const messageElements = await render(props.children, {
     stop: (e) =>
       e.tag == SystemMessage ||
@@ -276,7 +276,7 @@ export async function* OpenAIChatModel(
       e.tag == FunctionCall ||
       e.tag == FunctionResponse,
   });
-  yield '';
+  yield AI.AppendOnlyStream;
   const messages: ChatCompletionRequestMessage[] = await Promise.all(
     messageElements.filter(AI.isElement).map(async (message) => {
       switch (message.tag) {
@@ -393,7 +393,7 @@ export async function* OpenAIChatModel(
     if (delta.content) {
       currentMessage.content = currentMessage.content ?? '';
       currentMessage.content += delta.content;
-      yield currentMessage.content;
+      yield delta.content;
     }
     if (delta.function_call) {
       currentMessage.function_call = currentMessage.function_call ?? { name: '', arguments: '' };
@@ -416,7 +416,7 @@ export async function* OpenAIChatModel(
       />
     );
   }
-  return currentMessage.content ?? '';
+  return AI.AppendOnlyStream;
 }
 
 /**

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -409,7 +409,7 @@ export async function* OpenAIChatModel(
   logger.debug({ message: currentMessage }, 'Finished createChatCompletion');
 
   if (currentMessage.function_call) {
-    return (
+    yield (
       <FunctionCall
         name={currentMessage.function_call.name ?? ''}
         args={JSON.parse(currentMessage.function_call.arguments ?? '{}')}

--- a/packages/ai-jsx/src/stream/index.ts
+++ b/packages/ai-jsx/src/stream/index.ts
@@ -99,6 +99,27 @@ export function toStreamResponse(renderable: Renderable): Response {
   );
 }
 
+/**
+ * Converts a {@link Renderable} to a {@link ReadableStream} that will stream the rendered
+ * content as UTF-8 encoded text.
+ */
+export function toTextStream(renderable: Renderable): ReadableStream<Uint8Array> {
+  let previousValue = '';
+  const generator = createRenderContext().render(renderable, { appendOnly: true })[Symbol.asyncIterator]();
+  return new ReadableStream({
+    async pull(controller) {
+      const next = await generator.next();
+      const delta = next.value.slice(previousValue.length);
+      controller.enqueue(delta);
+      previousValue = next.value;
+
+      if (next.done) {
+        controller.close();
+      }
+    },
+  }).pipeThrough(new TextEncoderStream());
+}
+
 function streamResponseParser() {
   const SSE_PREFIX = 'data: ';
   const SSE_TERMINATOR = '\n\n';

--- a/packages/ai-jsx/src/stream/index.ts
+++ b/packages/ai-jsx/src/stream/index.ts
@@ -101,7 +101,9 @@ export function toStreamResponse(renderable: Renderable): Response {
 
 /**
  * Converts a {@link Renderable} to a {@link ReadableStream} that will stream the rendered
- * content as UTF-8 encoded text.
+ * content as an append-only UTF-8 encoded text stream. Compared to {@link toStreamResponse},
+ * this allows the response to be easily consumed by other frameworks (such as https://sdk.vercel.ai/)
+ * but does not support UI components or concurrently streaming multiple parts of the tree.
  */
 export function toTextStream(renderable: Renderable): ReadableStream<Uint8Array> {
   let previousValue = '';

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -19,6 +19,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "demo:append-only": "yarn build && node dist/append-only.js",
     "demo:debate": "yarn build && node dist/debate.js",
     "demo:errors": "yarn build && node dist/errors.js",
     "demo:logger": "yarn build && node dist/logger.js",

--- a/packages/examples/src/append-only.tsx
+++ b/packages/examples/src/append-only.tsx
@@ -1,0 +1,33 @@
+import { createRenderContext } from 'ai-jsx';
+import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
+
+function App() {
+  return (
+    <>
+      This example renders an AI.JSX tree in append-only mode, where rendering guarantees that each frame will append to
+      the previous one.{'\n'}
+      Here's some static text before!{'\n\n'}
+      Why is the sky blue?{' '}
+      <ChatCompletion>
+        <UserMessage>Why is the sky blue?</UserMessage>
+      </ChatCompletion>
+      {'\n\n'}
+      Why is Mars red?{' '}
+      <ChatCompletion>
+        <UserMessage>Why is Mars red?</UserMessage>
+      </ChatCompletion>
+      {'\n\n'}
+      And here's some static text after!
+    </>
+  );
+}
+
+let lastValue = '';
+const rendering = createRenderContext().render(<App />, { appendOnly: true });
+for await (const frame of rendering) {
+  process.stdout.write(frame.slice(lastValue.length));
+  lastValue = frame;
+}
+
+const finalResult = await rendering;
+process.stdout.write(finalResult.slice(lastValue.length));

--- a/packages/examples/src/opentelemetry.tsx
+++ b/packages/examples/src/opentelemetry.tsx
@@ -30,7 +30,7 @@ function OpenTelemetryTracer(props: { children: AI.Node }, { wrapRender }: AI.Co
     <>{props.children}</>,
     wrapRender((r) => {
       const tracer = opentelemetry.trace.getTracer('ai.jsx');
-      return (renderContext, renderable, shouldStop) =>
+      return (renderContext, renderable, shouldStop, appendOnly) =>
         AI.isElement(renderable)
           ? tracer.startActiveSpan(
               `<${renderable.tag.name}>`,
@@ -38,7 +38,7 @@ function OpenTelemetryTracer(props: { children: AI.Node }, { wrapRender }: AI.Co
               (span: opentelemetry.Span) => {
                 async function* gen() {
                   try {
-                    return yield* r(renderContext, renderable, shouldStop);
+                    return yield* r(renderContext, renderable, shouldStop, appendOnly);
                   } finally {
                     span.end();
                   }
@@ -47,7 +47,7 @@ function OpenTelemetryTracer(props: { children: AI.Node }, { wrapRender }: AI.Co
                 return bindAsyncGenerator(gen());
               }
             )
-          : r(renderContext, renderable, shouldStop);
+          : r(renderContext, renderable, shouldStop, appendOnly);
     })
   );
 }

--- a/packages/nextjs-demo/package.json
+++ b/packages/nextjs-demo/package.json
@@ -15,6 +15,7 @@
     "@types/node": "20.2.5",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
+    "ai": "^2.1.8",
     "ai-jsx": "0.5.6",
     "autoprefixer": "10.4.14",
     "classnames": "^2.3.2",

--- a/packages/nextjs-demo/src/app/basic-completion/api/text-stream/route.tsx
+++ b/packages/nextjs-demo/src/app/basic-completion/api/text-stream/route.tsx
@@ -1,0 +1,25 @@
+/** @jsxImportSource ai-jsx */
+import { toTextStream } from 'ai-jsx/stream';
+import { NextRequest } from 'next/server';
+import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
+import { StreamingTextResponse } from 'ai';
+
+export async function POST(request: NextRequest) {
+  const { topic } = await request.json();
+
+  return new StreamingTextResponse(
+    toTextStream(
+      <>
+        A poem about {topic}:{'\n\n'}
+        <ChatCompletion temperature={1}>
+          <UserMessage>Write me a poem about {topic}</UserMessage>
+        </ChatCompletion>
+        {'\n\n'}
+        Ten facts about {topic}:{'\n\n'}
+        <ChatCompletion temperature={1}>
+          <UserMessage>Give me ten facts about {topic}</UserMessage>
+        </ChatCompletion>
+      </>
+    )
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7531,7 +7531,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"ai@npm:^2.1.3":
+"ai@npm:^2.1.3, ai@npm:^2.1.8":
   version: 2.1.8
   resolution: "ai@npm:2.1.8"
   dependencies:
@@ -17348,6 +17348,7 @@ __metadata:
     "@types/react-dom": 18.2.4
     "@typescript-eslint/eslint-plugin": ^5.59.9
     "@typescript-eslint/parser": ^5.59.9
+    ai: ^2.1.8
     ai-jsx: 0.5.6
     autoprefixer: 10.4.14
     classnames: ^2.3.2


### PR DESCRIPTION
This adds underlying support for rendering to an append-only stream.

Components that will yield in an append-only manner can do so by yielding a special symbol, after which point all yielded values will be appended to, rather than replace, previously yielded values. (This indicates to rendering that it is safe to present intermediate content when append-only rendering is requested.)

This adds an API endpoint that demonstrates responding with a text stream that is compatible with Vercel's AI SDK but does not add any client-side demos.