### PR TITLE
Revert #164

### DIFF
--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -4,15 +4,8 @@
  * @packageDocumentation
  */
 
-import {
-  ChatCompletion,
-  FunctionCall,
-  FunctionParameter,
-  FunctionResponse,
-  SystemMessage,
-  UserMessage,
-} from '../core/completion.js';
-import { Node, RenderContext, isElement, Element } from '../index.js';
+import { ChatCompletion, FunctionParameter, SystemMessage, UserMessage } from '../core/completion.js';
+import { Node, RenderContext } from '../index.js';
 import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
@@ -114,7 +107,7 @@ export interface Tool {
    * A function to invoke the tool.
    */
   // Can we use Zod to do better than any[]?
-  func: (...args: any[]) => string | number | boolean | null | undefined | Promise<string | number | boolean | null>;
+  func: (...args: any[]) => unknown;
 }
 
 /**
@@ -190,84 +183,6 @@ export interface UseToolsProps {
  * ```
  *
  */
-export async function* UseTools(props: UseToolsProps, { render }: RenderContext) {
-  try {
-    const rendered = yield* render(<UseToolsFunctionCall {...props} />);
-    return rendered;
-  } catch (e: any) {
-    if (e.code === ErrorCode.ChatModelDoesNotSupportFunctions) {
-      return <UseToolsPromptEngineered {...props} />;
-    }
-    throw e;
-  }
-}
-
-/** @hidden */
-export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: RenderContext) {
-  const messages = [
-    <SystemMessage>You are a smart agent that may use functions to answer a user question.</SystemMessage>,
-  ];
-  if (props.fallback) {
-    messages.push(
-      <SystemMessage>Here's the fallback strategy/message if something failed: {props.fallback}</SystemMessage>
-    );
-  }
-  messages.push(<UserMessage>{props.query}</UserMessage>);
-
-  do {
-    const modelResponse = <ChatCompletion functionDefinitions={props.tools}>{messages}</ChatCompletion>;
-
-    const renderResult = yield* render(modelResponse, { stop: (el) => el.tag == FunctionCall });
-
-    const stringResponses: String[] = [];
-    let functionCallElement: Element<any> | null = null;
-
-    for (const element of renderResult) {
-      if (typeof element === 'string') {
-        // Model has generated a string response. Record it.
-        stringResponses.push(element);
-      } else if (isElement(element)) {
-        // Model has generated a function call.
-        if (functionCallElement) {
-          throw new AIJSXError(
-            `ChatCompletion returned 2 function calls at the same time ${renderResult.join(', ')}`,
-            ErrorCode.ModelOutputCouldNotBeParsedForTool,
-            'runtime'
-          );
-        }
-        functionCallElement = element;
-      } else {
-        throw new AIJSXError(
-          `Unexpected result from render ${renderResult.join(', ')}`,
-          ErrorCode.ModelOutputCouldNotBeParsedForTool,
-          'runtime'
-        );
-      }
-    }
-
-    if (functionCallElement) {
-      messages.push(functionCallElement);
-      yield functionCallElement;
-      // Call the selected function and append the result to the messages.
-      let response;
-      try {
-        const callable = props.tools[functionCallElement.props.name].func;
-        response = await callable(functionCallElement.props.args);
-      } catch (e: any) {
-        response = `Function called failed with error: ${e.message}.`;
-      } finally {
-        const functionResponse = <FunctionResponse name={functionCallElement.props.name}>{response}</FunctionResponse>;
-        yield functionResponse;
-        messages.push(functionResponse);
-      }
-    } else {
-      // Model did not generate any function call. Return the string responses.
-      return stringResponses.join('');
-    }
-  } while (true);
-}
-
-/** @hidden */
-export function UseToolsPromptEngineered(props: UseToolsProps) {
+export function UseTools(props: UseToolsProps) {
   return <InvokeTool tools={props.tools} toolChoice={<ChooseTools {...props} />} fallback={props.fallback} />;
 }

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -39,6 +39,7 @@ export type ModelComponent<T extends ModelPropsWithChildren> = Component<T>;
  * Represents a function definition that can be invoked using the {@link FunctionCall} component.
  */
 export interface FunctionDefinition {
+  name: string;
   description?: string;
   parameters: Record<string, FunctionParameter>;
 }

--- a/packages/ai-jsx/src/core/errors.ts
+++ b/packages/ai-jsx/src/core/errors.ts
@@ -24,7 +24,6 @@ export enum ErrorCode {
   AnthropicDoesNotSupportSystemMessage = 1019,
   AnthropicDoesNotSupportFunctions = 1020,
   AnthropicAPIError = 1021,
-  ChatModelDoesNotSupportFunctions = 1022,
 
   ModelOutputDidNotMatchConstraint = 2000,
 

--- a/packages/examples/src/chat-function-call.tsx
+++ b/packages/examples/src/chat-function-call.tsx
@@ -11,33 +11,11 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ModelProducesFunctionCall({ query }: { query: string }) {
   return (
-    <ChatCompletion
-      functionDefinitions={{
-        evaluate_expression: {
-          description: 'Evaluates a mathematical expression',
-          parameters: {
-            expression: {
-              description: 'The mathematical expression to be evaluated.',
-              type: 'string',
-              required: true,
-            },
-          },
-        },
-      }}
-    >
-      <SystemMessage>You are a tool that may use functions to answer a user question.</SystemMessage>
-      <UserMessage>{query}</UserMessage>
-    </ChatCompletion>
-  );
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ModelProducesFinalResponse({ query }: { query: string }) {
-  return (
     <ChatProvider model="gpt-4-0613">
       <ChatCompletion
-        functionDefinitions={{
-          evaluate_expression: {
+        functionDefinitions={[
+          {
+            name: 'evaluate_expression',
             description: 'Evaluates a mathematical expression',
             parameters: {
               expression: {
@@ -47,7 +25,33 @@ function ModelProducesFinalResponse({ query }: { query: string }) {
               },
             },
           },
-        }}
+        ]}
+      >
+        <SystemMessage>You are a tool that may use functions to answer a user question.</SystemMessage>
+        <UserMessage>{query}</UserMessage>
+      </ChatCompletion>
+    </ChatProvider>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function ModelProducesFinalResponse({ query }: { query: string }) {
+  return (
+    <ChatProvider model="gpt-4-0613">
+      <ChatCompletion
+        functionDefinitions={[
+          {
+            name: 'evaluate_expression',
+            description: 'Evaluates a mathematical expression',
+            parameters: {
+              expression: {
+                description: 'The mathematical expression to be evaluated.',
+                type: 'string',
+                required: true,
+              },
+            },
+          },
+        ]}
       >
         <SystemMessage>You are a tool that may use functions to answer a user question.</SystemMessage>
         <UserMessage>{query}</UserMessage>


### PR DESCRIPTION
It breaks the completion demo, creating this error:

```
[18:41:45.864] ERROR (ai-jsx/928): Rendering element <OpenAIChatModel> failed with exception: AI.JSX(1023): OpenAI createChatCompletion request failed with status code 400: None is not of type 'array' - 'functions'

For more information, see https://platform.openai.com/docs/guides/error-codes/api-errors.

This is a runtime error that's expected to occur with some frequency. It may go away on retry. It may be made more likely by errors in your code, or in AI.JSX.

Need help?
* Discord: https://discord.com/channels/1065011484125569147/1121125525142904862
* Docs: https://docs.ai-jsx.com/
* GH: https://github.com/fixie-ai/ai-jsx/issues
    exception: {
      "code": 1023,
      "blame": "runtime",
      "metadata": {},
      "statusCode": 400,
      "errorCode": 1023,
      "responseBody": "{\n  \"error\": {\n    \"message\": \"None is not of type 'array' - 'functions'\",\n    \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\": null\n  }\n}\n",
      "responseHeaders": {
        "access-control-allow-origin": "*",
        "alt-svc": "h3=\":443\"; ma=86400",
        "cf-cache-status": "DYNAMIC",
        "cf-ray": "7df1adc5adf71fec-IAD",
        "connection": "keep-alive",
        "content-length": "154",
        "content-type": "application/json",
        "date": "Thu, 29 Jun 2023 22:41:45 GMT",
        "openai-organization": "fixie-ai",
        "openai-processing-ms": "2",
        "openai-version": "2020-10-01",
        "server": "cloudflare",
        "strict-transport-security": "max-age=15724800; includeSubDomains",
        "x-ratelimit-limit-requests": "3500",
        "x-ratelimit-limit-tokens": "90000",
        "x-ratelimit-remaining-requests": "3499",
        "x-ratelimit-remaining-tokens": "89967",
        "x-ratelimit-reset-requests": "17ms",
        "x-ratelimit-reset-tokens": "22ms",
        "x-request-id": "70eda0c5d4d6dbd79070ffc1677ae173"
      },
      "errorResponse": {
        "error": {
          "message": "None is not of type 'array' - 'functions'",
          "type": "invalid_request_error",
          "param": null,
          "code": null
        }
      }
    }
    renderId: "106dd211-d2d8-4eba-b2ef-3d28b93e7fc8"
    element: "<OpenAIChatModel>"
```