### PR TITLE
Streaming JIT UI

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -316,6 +316,7 @@
     "openai": "^3.3.0",
     "pino": "^8.14.1",
     "server-only": "^0.0.1",
+    "untruncate-json": "^0.0.1",
     "uuid": "^9.0.0",
     "zod": "^3.21.4",
     "zod-to-json-schema": "^3.21.1"

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -171,10 +171,10 @@ async function* OneShotObjectCompletion(
       for (const validator of validatorsAndSchema) {
         validator(object);
       }
-    } catch (e) {
+    } catch (e: any) {
       if (partial.done) {
         logger.warn(
-          { output: partial.value, cleaned: partialResultCleaner ? str : undefined },
+          { output: partial.value, cleaned: partialResultCleaner ? str : undefined, errorMessage: e.message },
           "ObjectCompletion failed. The final result either didn't parse or didn't validate."
         );
         throw e;

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -22,7 +22,7 @@ export type ObjectCompletion = ModelPropsWithChildren & {
   /** Validators are used to ensure that the final object looks as expected. */
   validators?: ((obj: object) => void)[];
   /**
-   * The object Schema that is required. This is a type of validator with the excpetion
+   * The object Schema that is required. This is a type of validator with the exception
    * that the schema description is also provided to the model.
    */
   schema?: z.Schema;
@@ -42,7 +42,7 @@ export type TypedObjectCompletion = ObjectCompletion & {
   /**
    * The intermediate results that get yielded might be incomplete and as such
    * a cleaning/healing/untruncating step might be required.
-   * For example, see the `untrunctate-json` package.
+   * For example, see the `untruncate-json` package.
    */
   partialResultCleaner?: (str: string) => string;
 };
@@ -241,7 +241,7 @@ async function* ObjectCompletionWithRetry(
     }
 
     logger.debug(
-      { atempt: retryIndex + 1, expectedFormat: props.typeName, output },
+      { attempt: retryIndex + 1, expectedFormat: props.typeName, output },
       `Output did not validate to ${props.typeName}.`
     );
   }

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -5,39 +5,90 @@
  */
 
 import * as AI from '../index.js';
-import { ChatCompletion, SystemMessage, AssistantMessage, UserMessage } from '../core/completion.js';
+import {
+  ChatCompletion,
+  SystemMessage,
+  AssistantMessage,
+  UserMessage,
+  ModelPropsWithChildren,
+} from '../core/completion.js';
 import yaml from 'js-yaml';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
+import z from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import untruncateJson from 'untruncate-json';
 
-interface ValidationResult {
-  success: boolean;
-  error: string;
-}
+export type ObjectCompletion = ModelPropsWithChildren & {
+  /** Validators are used to ensure that the final object looks as expected. */
+  validators?: ((obj: object) => void)[];
+  /**
+   * The object Schema that is required. This is a type of validator with the excpetion
+   * that the schema description is also provided to the model.
+   */
+  schema?: z.Schema;
+  /** Any output example to be shown to the model. */
+  example?: string;
+  // TODO (@farzad): better name/framing for example.
+};
 
-// TODO: schema
+export type TypedObjectCompletion = ObjectCompletion & {
+  /** Human-readable name of the type, e.g. JSON or YAML. */
+  typeName: string;
+  /**
+   * Object parser: creates the object to be evaluated given the string.
+   * Note: the parser is only used for validation. The final output is still a string.
+   */
+  parser: (str: string) => object;
+  /**
+   * The intermediate results that get yielded might be incomplete and as such
+   * a cleaning/healing/untruncating step might be required.
+   * For example, see the `untrunctate-json` package.
+   */
+  partialResultCleaner?: (str: string) => string;
+};
+
+export type TypedObjectCompletionWithRetry = TypedObjectCompletion & { retries?: number };
+
 /**
  * A {@link ChatCompletion} component that constrains the output to be a valid JSON string.
  * It uses a combination of prompt engineering and validation with retries to ensure that the output is valid.
  *
+ * Though not required, you can provide a Zod schema to validate the output against. This is useful for
+ * ensuring that the output is of the expected type.
+ *
  * @example
  * ```tsx
+ * const FamilyTree: z.Schema = z.array(
+ *   z.object({
+ *     name: z.string(),
+ *     children: z.lazy(() => FamilyTree).optional(),
+ *   })
+ * );
+ *
+ * return (
  *    <JsonChatCompletion>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.
  *     </UserMessage>
  *    </JsonChatCompletion>
+ * );
  * ```
- *
- * @param retries The maximum number of times to retry the completion if the output is invalid.
- * @param children The children to render.
  * @returns A string that is a valid JSON or throws an error after `retries` attempts.
+ *    Intermediate results that are valid, are also yielded.
  */
-export function JsonChatCompletion({ children, ...props }: { children: AI.Node }) {
-  return (
-    <ObjectFormatChatCompletion typeName="JSON" validator={isJsonString} {...{ ...props }}>
-      {children}
-    </ObjectFormatChatCompletion>
+export async function* JsonChatCompletion(
+  props: Omit<TypedObjectCompletionWithRetry, 'typeName' | 'parser' | 'partialResultCleaner'>,
+  { render }: AI.ComponentContext
+) {
+  return yield* render(
+    <ObjectCOmpletionWithRetry
+      {...props}
+      typeName="JSON"
+      parser={JSON.parse}
+      // TODO: can we remove .default?
+      partialResultCleaner={untruncateJson.default}
+    />
   );
 }
 
@@ -45,129 +96,164 @@ export function JsonChatCompletion({ children, ...props }: { children: AI.Node }
  * A {@link ChatCompletion} component that constrains the output to be a valid YAML string.
  * It uses a combination of prompt engineering and validation with retries to ensure that the output is valid.
  *
- *  @example
+ * Though not required, you can provide a Zod schema to validate the output against. This is useful for
+ * ensuring that the output is of the expected type.
+ *
+ * @example
  * ```tsx
+ * const FamilyTree: z.Schema = z.array(
+ *   z.object({
+ *     name: z.string(),
+ *     children: z.lazy(() => FamilyTree).optional(),
+ *   })
+ * );
+ *
+ * return (
  *    <YamlChatCompletion>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.
  *     </UserMessage>
  *    </YamlChatCompletion>
+ * );
  * ```
- *
- * @param retries The maximum number of times to retry the completion if the output is invalid.
- * @param children The children to render.
  * @returns A string that is a valid YAML or throws an error after `retries` attempts.
+ *    Intermediate results that are valid, are also yielded.
  */
-export function YamlChatCompletion({ children, ...props }: { children: AI.Node }) {
-  return (
-    <ObjectFormatChatCompletion typeName="YAML" validator={isYamlString} {...{ ...props }}>
-      {children}
-    </ObjectFormatChatCompletion>
+export async function* YamlChatCompletion(
+  props: Omit<TypedObjectCompletionWithRetry, 'typeName' | 'parser'>,
+  { render }: AI.ComponentContext
+) {
+  return yield* render(
+    <ObjectCOmpletionWithRetry {...props} typeName="YAML" parser={yaml.load as (str: string) => object} />
   );
 }
 
 /**
  * A {@link ChatCompletion} component that constrains the output to be a valid object format (e.g. JSON/YAML).
  *
- * @param retries The maximum number of times to retry the completion if the output is invalid.
- * @param validator A function that returns a {@link ValidationResult} for a given string.
- * @param typeName The name of the type, to be used in the prompt.
- * @param children The children to render.
- * @returns A string that validates as the given type or throws an error after `retries` attempts
+ * Though not required, you can provide a Zod schema to validate the output against. This is useful for
+ * ensuring that the output is of the expected type.
+ *
+ * @returns A string that validates as the given type or throws an error.
+ *    Intermediate results that are valid, are also yielded.
  */
-async function ObjectFormatChatCompletion(
-  {
-    retries = 3,
-    validator,
-    typeName,
-    children,
-    ...props
-  }: {
-    validator: (str: string) => ValidationResult;
-    /** function that succeeds if output string is of the expected format */
-    typeName: string;
-    /** name of the type, to be used in the prompt */
-    retries?: number;
-    /** retries if output fails validation, how many times should we retry.
-     * Note: you can have `1 + retries` LLM calls in total. */
-    children: AI.Node;
-  },
+async function* OneShotObjectCompletion(
+  { children, typeName, validators, example, schema, parser, partialResultCleaner, ...props }: TypedObjectCompletion,
   { render, logger }: AI.ComponentContext
 ) {
+  // If a schema is provided, it is added to the list of validators as well as the prompt.
+  const validatorsAndSchema = schema ? [schema.parse, ...(validators ?? [])] : validators ?? [];
+
   const childrenWithCompletion = (
     <ChatCompletion {...props}>
       {children}
       <SystemMessage>
-        Your response must be a valid {typeName}. Do not include ```{typeName.toLowerCase()} ``` code blocks.
+        Respond with a {typeName} object that encodes your response.
+        {schema
+          ? `The ${typeName} object should match this JSON Schema: ${JSON.stringify(zodToJsonSchema(schema))}`
+          : ''}
+        {example ? `For example: \n${example}` : ''}
+        Respond with only the {typeName} object. Do not include any explanatory prose. Do not include ```
+        {typeName.toLowerCase()} ``` code blocks.
       </SystemMessage>
     </ChatCompletion>
   );
+  const renderGenerator = render(childrenWithCompletion)[Symbol.asyncIterator]();
 
-  let output = await render(childrenWithCompletion);
-  let valiationResults = validator(output);
-  if (valiationResults.success) {
-    return output;
+  // TODO: we can possibly add a timelimit here so we don't emit too many times.
+  let lastYieldedLen = 0;
+  while (true) {
+    const partial = await renderGenerator.next();
+    const str = partialResultCleaner ? partialResultCleaner(partial.value) : partial.value;
+    try {
+      const object = parser(str);
+      for (const validator of validatorsAndSchema) {
+        validator(object);
+      }
+    } catch (e) {
+      if (partial.done) {
+        logger.warn(
+          { output: partial.value, cleaned: partialResultCleaner ? str : undefined },
+          "ObjectCompletion failed. The final result either didn't parse or didn't validate."
+        );
+        throw e;
+      }
+      continue;
+    }
+    if (partial.done) {
+      return str;
+    }
+    if (str.length > lastYieldedLen) {
+      lastYieldedLen = str.length;
+      yield str;
+    }
   }
 
-  logger.debug({ atempt: 1, expectedFormat: typeName, output }, `Output did not validate to ${typeName}.`);
+  // TODO: return an AIJSXError instead? The issue is I want to get the original (unmodified) error message somehow.
+}
+
+/**
+ * A {@link ChatCompletion} component that constrains the output to be a valid object format (e.g. JSON/YAML).
+ * If the first attempt fails, it will retry with a new prompt up to `retries` times.
+ *
+ * @returns A string that validates as the given type or throws an error after `retries` attempts
+ *    Intermediate results that are valid, are also yielded.
+ */
+async function* ObjectCOmpletionWithRetry(
+  { children, retries = 3, ...props }: TypedObjectCompletionWithRetry,
+  { render, logger }: AI.ComponentContext
+) {
+  const childrenWithCompletion = <OneShotObjectCompletion {...props}>{children}</OneShotObjectCompletion>;
+
+  let output;
+  let validationError: string;
+  try {
+    output = yield* render(childrenWithCompletion);
+    return output;
+  } catch (e: any) {
+    validationError = e.message;
+  }
+
+  logger.debug({ atempt: 1, expectedFormat: props.typeName, output }, `Output did not validate to ${props.typeName}.`);
 
   for (let retryIndex = 1; retryIndex < retries; retryIndex++) {
     const completionRetry = (
-      <ChatCompletion {...props}>
+      <OneShotObjectCompletion {...props}>
         <SystemMessage>
-          You are a {typeName} object generator. Create a {typeName} object (context redacted).
+          You are a {props.typeName} object generator. Create a {props.typeName} object (context redacted).
         </SystemMessage>
         <AssistantMessage>{output}</AssistantMessage>
         <UserMessage>
-          Try again. Here's the validation error when trying to parse the output as {typeName}:{'\n'}
-          {valiationResults.error}
+          Try again. Here's the validation error when trying to parse the output as {props.typeName}:{'\n'}
+          {validationError}
           {'\n'}
-          You must reformat the string to be a valid {typeName} object, but you must keep the same data. Do not explain
-          the issue, just return a string that can be parsed as {typeName} as-is. Do not include ```
-          {typeName.toLocaleLowerCase()} ``` code blocks.
+          You must reformat the string to be a valid {props.typeName} object, but you must keep the same data.
         </UserMessage>
-      </ChatCompletion>
+      </OneShotObjectCompletion>
     );
 
-    output = await render(completionRetry);
-    valiationResults = validator(output);
-    if (valiationResults.success) {
+    try {
+      output = yield* render(completionRetry);
       return output;
+    } catch (e: any) {
+      validationError = e.message;
     }
 
     logger.debug(
-      { atempt: retryIndex + 1, expectedFormat: typeName, output },
-      `Output did not validate to ${typeName}.`
+      { atempt: retryIndex + 1, expectedFormat: props.typeName, output },
+      `Output did not validate to ${props.typeName}.`
     );
   }
 
   throw new AIJSXError(
-    `The model did not produce a valid ${typeName} object, even after ${retries} attempts.`,
+    `The model did not produce a valid ${props.typeName} object, even after ${retries} attempts.`,
     ErrorCode.ModelOutputDidNotMatchConstraint,
     'runtime',
     {
-      typeName,
+      typeName: props.typeName,
       retries,
       output,
     }
   );
-}
-
-function isJsonString(str: string): ValidationResult {
-  try {
-    JSON.parse(str);
-    return { success: true, error: '' };
-  } catch (e: any) {
-    return { success: false, error: e.message };
-  }
-}
-
-function isYamlString(str: string): ValidationResult {
-  try {
-    yaml.load(str);
-    return { success: true, error: '' } as ValidationResult;
-  } catch (e: any) {
-    return { success: false, error: e.message } as ValidationResult;
-  }
 }

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -82,7 +82,7 @@ export async function* JsonChatCompletion(
   { render }: AI.ComponentContext
 ) {
   return yield* render(
-    <ObjectCOmpletionWithRetry
+    <ObjectCompletionWithRetry
       {...props}
       typeName="JSON"
       parser={JSON.parse}
@@ -125,7 +125,7 @@ export async function* YamlChatCompletion(
   { render }: AI.ComponentContext
 ) {
   return yield* render(
-    <ObjectCOmpletionWithRetry {...props} typeName="YAML" parser={yaml.load as (str: string) => object} />
+    <ObjectCompletionWithRetry {...props} typeName="YAML" parser={yaml.load as (str: string) => object} />
   );
 }
 
@@ -200,7 +200,7 @@ async function* OneShotObjectCompletion(
  * @returns A string that validates as the given type or throws an error after `retries` attempts
  *    Intermediate results that are valid, are also yielded.
  */
-async function* ObjectCOmpletionWithRetry(
+async function* ObjectCompletionWithRetry(
   { children, retries = 3, ...props }: TypedObjectCompletionWithRetry,
   { render, logger }: AI.ComponentContext
 ) {

--- a/packages/ai-jsx/src/react/completion.tsx
+++ b/packages/ai-jsx/src/react/completion.tsx
@@ -81,7 +81,9 @@ export async function* UICompletion(
   }
 
   const Element: z.Schema = z.object({
-    name: z.string(),
+    name: z.string().refine((c) => Boolean(validComponents[c]), {
+      message: `Unknown component "name". Supported components: ${Object.keys(validComponents)}`,
+    }),
     children: z.array(z.union([z.string(), z.lazy(() => Element)])),
   });
 

--- a/packages/ai-jsx/src/react/completion.tsx
+++ b/packages/ai-jsx/src/react/completion.tsx
@@ -1,9 +1,11 @@
 /** @jsxImportSource ai-jsx/react */
 import * as AI from './core.js';
 import React from 'react';
-import { ChatCompletion, SystemMessage, UserMessage } from '../core/completion.js';
+import { SystemMessage, UserMessage } from '../core/completion.js';
+import { JsonChatCompletion } from '../batteries/constrained-output.js';
 import { isJsxBoundary } from './jsx-boundary.js';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
+import z from 'zod';
 
 function reactComponentName(component: React.JSXElementConstructor<any> | string) {
   return typeof component === 'string' ? component : component.name;
@@ -40,28 +42,6 @@ export async function* UICompletion(
   }
 
   collectComponents(example, true);
-
-  const modelResult = await render(
-    <ChatCompletion>
-      <SystemMessage>
-        You are an AI who is an expert UI designer. The user will provide content in the form of text and you will
-        respond using a set of React components to create a UI for the content. Here are the only available React
-        components and how they should be used:
-        {'\n'}
-        <AI.React>{example}</AI.React>
-        {'\n'}
-        Respond with a JSON object that encodes your UI. The JSON object should match this TypeScript interface:
-        interface Element {'{'}
-        name: string; children: (string | Element)[]
-        {'}'}
-        For example:{'\n'}
-        {'<'}SomeComponent /{'>'}
-        Becomes: {'{'} "name": "SomeComponent", "children": []{'}'}. Respond with only the JSON. Do not include any
-        explanatory prose. Do not use any elements (including HTML elements) other than the ones above.
-      </SystemMessage>
-      <UserMessage>{children}</UserMessage>
-    </ChatCompletion>
-  );
 
   const validComponents = Object.fromEntries(Array.from(reactComponents).map((c) => [reactComponentName(c), c]));
 
@@ -100,5 +80,35 @@ export async function* UICompletion(
     return <Component>{children.map(toComponent)}</Component>;
   }
 
-  return <AI.React>{toComponent(JSON.parse(modelResult))}</AI.React>;
+  const Element: z.Schema = z.object({
+    name: z.string(),
+    children: z.array(z.union([z.string(), z.lazy(() => Element)])),
+  });
+
+  const modelRenderGenerator = render(
+    <JsonChatCompletion
+      schema={Element}
+      example={'<SomeComponent /> becomes: { "name": "SomeComponent", "children": [] }'}
+    >
+      <SystemMessage>
+        You are an AI who is an expert UI designer. The user will provide content in the form of text and you will
+        respond using a set of React components to create a UI for the content. Here are the only available React
+        components and how they should be used:
+        {'\n'}
+        <AI.React>{example}</AI.React>
+        {'\n'}
+        Do not use any elements (including HTML elements) other than the ones above.
+      </SystemMessage>
+      <UserMessage>{children}</UserMessage>
+    </JsonChatCompletion>
+  )[Symbol.asyncIterator]();
+
+  while (true) {
+    const modelResult = await modelRenderGenerator.next();
+    const component = <AI.React>{toComponent(JSON.parse(modelResult.value))}</AI.React>;
+    if (modelResult.done) {
+      return component;
+    }
+    yield component;
+  }
 }

--- a/packages/docs/docs/guides/prompting.md
+++ b/packages/docs/docs/guides/prompting.md
@@ -86,5 +86,27 @@ function App() {
 }
 ```
 
+You can also enforce a certain _Schema_ so that the output matches the format you want:
+
+```tsx
+// We use `zod` library to create and enforce the schema
+import z from 'zod';
+
+const FamilyTree: z.Schema = z.array(
+  z.object({
+    name: z.string(),
+    children: z.lazy(() => FamilyTree).optional(),
+  })
+);
+
+function App() {
+  return (
+    <JsonChatCompletion schema={FamilyTree}>
+      <UserMessage>Create a nested family tree with names and ages. It should include a total of 5 people</UserMessage>
+    </JsonChatCompletion>
+  );
+}
+```
+
 Under the hood, this model will use a combination of prompting, validating the output, and asking them the model to retry
 if the validation fails (refer to [`ai-jsx/batteries/constrained-output`](../api/modules/batteries_constrained_output)).

--- a/packages/docs/docs/tutorial/part3-constrained-output.md
+++ b/packages/docs/docs/tutorial/part3-constrained-output.md
@@ -123,3 +123,25 @@ For example, the `<JsonChatCompletion>` component will emit:
 Internally, the `<JsonChatCompletion>` and `<YamlChatCompletion>` components prompt the
 LLM to take the input data, format it as JSON or YAML, and check that the resulting objects
 correctly parse in the target format.
+
+You can even enforce an _object Schema_ to make sure the output matches the format you want:
+
+```tsx filename="packages/tutorial/src/constrained-output.tsx"
+import z from 'zod';
+
+const characterSchema = z.object({
+  name: z.string(),
+  class: z.string(),
+  race: z.string(),
+  weapons: z.array(z.string()),
+  spells: z.array(z.string()),
+});
+
+const app = (
+  // ...
+  <JsonChatCompletion schema={characterSchema}>
+    <UserMessage>{conversation}</UserMessage>
+  </JsonChatCompletion>
+  // ...
+);
+```

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -1,18 +1,26 @@
 import { UserMessage } from 'ai-jsx/core/completion';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
 import { showInspector } from 'ai-jsx/core/inspector';
+import z from 'zod';
+
+const FamilyTree: z.Schema = z.array(
+  z.object({
+    name: z.string(),
+    children: z.lazy(() => FamilyTree).optional(),
+  })
+);
 
 function App() {
   const query = 'Create a nested family tree with names and ages. It should include a total of 5 people.';
   return (
     <>
       JSON generation example:{'\n'}
-      <JsonChatCompletion>
+      <JsonChatCompletion schema={FamilyTree}>
         <UserMessage>{query}</UserMessage>
       </JsonChatCompletion>
       {'\n\n'}
       YAML generation example:{'\n'}
-      <YamlChatCompletion>
+      <YamlChatCompletion schema={FamilyTree}>
         <UserMessage>{query}</UserMessage>
       </YamlChatCompletion>
     </>

--- a/packages/tutorial/src/constrained-output.tsx
+++ b/packages/tutorial/src/constrained-output.tsx
@@ -2,6 +2,7 @@ import { ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completi
 import { Inline } from 'ai-jsx/core/inline';
 import { showInspector } from 'ai-jsx/core/inspector';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
+import z from 'zod';
 
 function CharacterField(props: { fieldName: string }) {
   return (
@@ -36,20 +37,28 @@ function CharacterGenerator() {
   );
 }
 
+const characterSchema = z.object({
+  name: z.string(),
+  class: z.string(),
+  race: z.string(),
+  weapons: z.array(z.string()),
+  spells: z.array(z.string()),
+});
+
 const app = (
   <Inline>
     <CharacterGenerator />
     {'\n\n'}
     The following is a JSON representation of this character profile:{'\n'}
     {(conversation) => (
-      <JsonChatCompletion>
+      <JsonChatCompletion schema={characterSchema}>
         <UserMessage>{conversation}</UserMessage>
       </JsonChatCompletion>
     )}
     {'\n\n'}
     And here is a YAML representation of this character profile:{'\n'}
     {(conversation) => (
-      <YamlChatCompletion>
+      <YamlChatCompletion schema={characterSchema}>
         <UserMessage>{conversation}</UserMessage>
       </YamlChatCompletion>
     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7599,6 +7599,7 @@ __metadata:
     ts-node: ^10.9.1
     type-fest: ^3.10.0
     typescript: ^5.1.3
+    untruncate-json: ^0.0.1
     uuid: ^9.0.0
     write-json-file: ^5.0.0
     zod: ^3.21.4
@@ -23155,6 +23156,13 @@ __metadata:
   version: 4.0.0
   resolution: "untildify@npm:4.0.0"
   checksum: 39ced9c418a74f73f0a56e1ba4634b4d959422dff61f4c72a8e39f60b99380c1b45ed776fbaa0a4101b157e4310d873ad7d114e8534ca02609b4916bb4187fb9
+  languageName: node
+  linkType: hard
+
+"untruncate-json@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "untruncate-json@npm:0.0.1"
+  checksum: e2e919bd25b4fd6a5b35be254d286643d6bc966d8a7b5792dcd21affd1a2e510aa9d24138138dc70263afbe9cd0b4f5cca2b6dae5a9df10841b4649231b15744
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:
- Adds schemas to JSON completion;
- Enables streaming JIT UI.

### What is UI streaming?
We had _streaming for text_, but not when you generate a UI (so it seems slow to load). I guess you can simply compare [Nick's video](https://fixie-ai.slack.com/archives/C05B6EE9JE5/p1688140097512069) (without streaming) and [mine](https://www.loom.com/share/383e49e3ce1e49aca9530cb7b1dbff70) (with streaming) from Friday.

### Is it a good idea?
Not sure. People had reservations about it in the meeting, but the response to the video seemed positive so I rolled with it. I won't merge it before we get more positive feedback though.

### How does it work?
The idea is that as soon as we have a "valid" prefix of the output, we try to generate & show the UI. With YAML it makes a lot of sense. With JSON, it can only work if you can somehow **"heal" or "untruncate"** or in anyway fix the end. Fortunately there are [JS libraries for that](https://github.com/dphilipson/untruncate-json) (I tried another one and it wasn't as good)!

### Yaml vs JSON:
- Minified JSON: not gonna use it, because apparently the response is less reliable. I think the extra tabs/newlines are actually helping the model quite a bit. Same is true of minified YAML.
- YAML: it's basically the same as JSON, because the model most of the time does return a JSON (as JSON seems to be accepted as YAML). At that point the difference is negligible.
   - Also, with YAML I kept seeing the word `name` at the end of the responses. This is because it thought the start of a new component (which starts with `name:` is a string itself). This doesn't happen with JSON purely out of luck as `":` seems to be a single token and we never get `"name"` in the output :sweat_smile:
- Also, with JSON (and minified json), the `untruncate-json` does a good job of healing a cut-off JSON, so if they're not that different let's keep JSON (I found no similar package for YAML)
- Another reason: JSON is compatible with FunctionCall, so we can easily use that if we decide it's more reliable than prompt engineering.


TL/DR for formats: unfortunately minified versions aren't as reliable. JSON with `untruncate-json` is better than YAML. Also YAML sometimes returns a small incorrect part at the end (`name`) that JSON luckily avoids.