### PR TITLE
JsonCompletion with FunctionCall

### DIFF
--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -273,7 +273,7 @@ async function* ObjectCompletionWithRetry(
  * It (ab)uses OpenAI function calls to generate the JSON string.
  *
  * @returns A string that is a valid JSON or throws an error.
- * 
+ *
  * @hidden
  */
 async function* JsonChatCompletionFunctionCall(

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -302,7 +302,6 @@ export async function JsonChatCompletionFunctionCall(
 
   const lastYield = output[output.length - 1];
   if (AI.isElement(lastYield) && lastYield.tag == FunctionCall) {
-    console.log('args', lastYield.props.args);
     // TODO: is validation necessary? If yes, how to handle errors?
     schema.parse(lastYield.props.args);
     return JSON.stringify(lastYield.props.args);

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -10,7 +10,6 @@ import {
   SystemMessage,
   AssistantMessage,
   UserMessage,
-  FunctionCall,
   ModelPropsWithChildren,
 } from '../core/completion.js';
 import yaml from 'js-yaml';
@@ -25,8 +24,11 @@ export type ObjectCompletion = ModelPropsWithChildren & {
   /**
    * The object Schema that is required. This is a type of validator with the exception
    * that the schema description is also provided to the model.
+   *
+   * @note To match OpenAI function definition specs, the schema must be a Zod object.
+   * Arrays and other types should be wrapped in a top-level object in order to be used.
    */
-  schema?: z.Schema;
+  schema?: z.ZodObject<any>;
   /** Any output example to be shown to the model. */
   example?: string;
   // TODO (@farzad): better name/framing for example.
@@ -66,8 +68,12 @@ export type TypedObjectCompletionWithRetry = TypedObjectCompletion & { retries?:
  *   })
  * );
  *
+ * const RootFamilyTree: z.ZodObject<any> = z.object({
+ *   tree: FamilyTree,
+ * });
+ *
  * return (
- *    <JsonChatCompletion schema={FamilyTree}>
+ *    <JsonChatCompletion schema={RootFamilyTree}>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.
@@ -117,9 +123,12 @@ export async function* JsonChatCompletion(
  *     children: z.lazy(() => FamilyTree).optional(),
  *   })
  * );
+ * const RootFamilyTree: z.ZodObject<any> = z.object({
+ *   tree: FamilyTree,
+ * });
  *
  * return (
- *    <YamlChatCompletion schema={FamilyTree}>
+ *    <YamlChatCompletion schema={RootFamilyTree}>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -79,9 +79,19 @@ export type TypedObjectCompletionWithRetry = TypedObjectCompletion & { retries?:
  *    Intermediate results that are valid, are also yielded.
  */
 export async function* JsonChatCompletion(
-  props: Omit<TypedObjectCompletionWithRetry, 'typeName' | 'parser' | 'partialResultCleaner'>,
+  { schema, ...props }: Omit<TypedObjectCompletionWithRetry, 'typeName' | 'parser' | 'partialResultCleaner'>,
   { render }: AI.ComponentContext
 ) {
+  if (schema) {
+    try {
+      // TODO: do not merge with this. This screws up progressive loading.
+      return yield* render(<JsonChatCompletionFunctionCall schema={schema} {...props} />);
+    } catch (e: any) {
+      if (e.code !== ErrorCode.ChatModelDoesNotSupportFunctions) {
+        throw e;
+      }
+    }
+  }
   return yield* render(
     <ObjectCompletionWithRetry
       {...props}

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -67,7 +67,7 @@ export type TypedObjectCompletionWithRetry = TypedObjectCompletion & { retries?:
  * );
  *
  * return (
- *    <JsonChatCompletion>
+ *    <JsonChatCompletion schema={FamilyTree}>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.
@@ -119,7 +119,7 @@ export async function* JsonChatCompletion(
  * );
  *
  * return (
- *    <YamlChatCompletion>
+ *    <YamlChatCompletion schema={FamilyTree}>
  *     <UserMessage>
  *      Create a nested family tree with names and ages.
  *      It should include a total of 5 people.
@@ -171,7 +171,6 @@ async function* OneShotObjectCompletion(
   );
   const renderGenerator = render(childrenWithCompletion)[Symbol.asyncIterator]();
 
-  // TODO: we can possibly add a timelimit here so we don't emit too many times.
   let lastYieldedLen = 0;
   while (true) {
     const partial = await renderGenerator.next();
@@ -276,7 +275,7 @@ async function* ObjectCompletionWithRetry(
  *
  * @hidden
  */
-async function* JsonChatCompletionFunctionCall(
+export async function* JsonChatCompletionFunctionCall(
   { schema, children, ...props }: ModelPropsWithChildren & { schema: z.Schema },
   { render }: AI.ComponentContext
 ) {

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -273,8 +273,10 @@ async function* ObjectCompletionWithRetry(
  * It (ab)uses OpenAI function calls to generate the JSON string.
  *
  * @returns A string that is a valid JSON or throws an error.
+ * 
+ * @hidden
  */
-export async function* JsonChatCompletionFunctionCall(
+async function* JsonChatCompletionFunctionCall(
   { schema, children, ...props }: ModelPropsWithChildren & { schema: z.Schema },
   { render }: AI.ComponentContext
 ) {

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -7,7 +7,7 @@
 import {
   ChatCompletion,
   FunctionCall,
-  FunctionParameter,
+  FunctionParameters,
   FunctionResponse,
   SystemMessage,
   UserMessage,
@@ -108,7 +108,7 @@ export interface Tool {
   /**
    * A map of parameter names to their description and type.
    */
-  parameters: Record<string, FunctionParameter>;
+  parameters: FunctionParameters;
 
   /**
    * A function to invoke the tool.

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -49,7 +49,13 @@ export function getParametersSchema(parameters: FunctionParameters) {
   if (parameters instanceof z.Schema) {
     const jsonSchema = zodToJsonSchema(parameters);
     if (!('type' in jsonSchema) || jsonSchema.type !== 'object') {
-      throw new Error('Function parameters must be an object');
+      throw new AIJSXError(
+        `Function parameters param must be an object, but was: ${JSON.stringify(jsonSchema, null, 2)}`,
+        ErrorCode.InvalidParamSchemaType,
+        'ambiguous',
+        // @ts-expect-error
+        { jsonSchema }
+      );
     }
     return jsonSchema;
   }

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -45,19 +45,17 @@ export interface FunctionDefinition {
   parameters: FunctionParameters;
 }
 
+/**
+ * This function creates a [JSON Schema](https://json-schema.org/) object to describe
+ * parameters for a {@link FunctionDefinition}.
+ * The parameters can be described either using a record of parameter names to
+ * {@link PlainFunctionParameter} objects, or using a {@link z.ZodObject} schema object.
+ *
+ * @note If using a Zod schema, the top-level schema must be an object as per OpenAI specifications.
+ */
 export function getParametersSchema(parameters: FunctionParameters) {
-  if (parameters instanceof z.Schema) {
-    const jsonSchema = zodToJsonSchema(parameters);
-    if (!('type' in jsonSchema) || jsonSchema.type !== 'object') {
-      throw new AIJSXError(
-        `Function parameters param must be an object, but was: ${JSON.stringify(jsonSchema, null, 2)}`,
-        ErrorCode.InvalidParamSchemaType,
-        'ambiguous',
-        // @ts-expect-error
-        { jsonSchema }
-      );
-    }
-    return jsonSchema;
+  if (parameters instanceof z.ZodObject) {
+    return zodToJsonSchema(parameters);
   }
   return {
     type: 'object',
@@ -88,9 +86,12 @@ export interface PlainFunctionParameter {
  *
  * This type allows two ways for specifying parameters:
  * - For simple use cases, a record of parameter names to {@link PlainFunctionParameter} objects.
- * - For more complex use cases, a {@link z.Schema} object (`zod` is a standard runtime type definition & checking library).
+ * - For more complex use cases, a {@link z.ZodObject} schema object (`zod` is a standard runtime type definition & checking library).
+ *
+ * @note If using a Zod schema, the top-level schema must be an object as per OpenAI specifications:
+ * https://platform.openai.com/docs/api-reference/chat/create#chat/create-parameters
  */
-export type FunctionParameters = Record<string, PlainFunctionParameter> | z.Schema;
+export type FunctionParameters = Record<string, PlainFunctionParameter> | z.ZodObject<any>;
 
 /**
  * If env var `OPENAI_API_KEY` is defined, use Open AI as the completion model provider.

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -48,10 +48,8 @@ export interface FunctionDefinition {
 /**
  * This function creates a [JSON Schema](https://json-schema.org/) object to describe
  * parameters for a {@link FunctionDefinition}.
- * The parameters can be described either using a record of parameter names to
- * {@link PlainFunctionParameter} objects, or using a {@link z.ZodObject} schema object.
  *
- * @note If using a Zod schema, the top-level schema must be an object as per OpenAI specifications.
+ * See {@link FunctionParameters} for more information on what parameters are supported.
  */
 export function getParametersSchema(parameters: FunctionParameters) {
   if (parameters instanceof z.ZodObject) {
@@ -90,6 +88,12 @@ export interface PlainFunctionParameter {
  *
  * @note If using a Zod schema, the top-level schema must be an object as per OpenAI specifications:
  * https://platform.openai.com/docs/api-reference/chat/create#chat/create-parameters
+ *
+ * For example, to describe a list of strings, the following is not accepted:
+ * `const schema: z.Schema = z.array(z.string())`
+ *
+ * Instead, you can wrap it in an object like so:
+ * `const schema: z.ZodObject = z.object({ arr: z.array(z.string()) })`
  */
 export type FunctionParameters = Record<string, PlainFunctionParameter> | z.ZodObject<any>;
 

--- a/packages/ai-jsx/src/core/errors.ts
+++ b/packages/ai-jsx/src/core/errors.ts
@@ -25,6 +25,8 @@ export enum ErrorCode {
   AnthropicDoesNotSupportFunctions = 1020,
   AnthropicAPIError = 1021,
   ChatModelDoesNotSupportFunctions = 1022,
+  ChatCompletionBadInput = 1023,
+  InvalidParamSchemaType = 1024,
 
   ModelOutputDidNotMatchConstraint = 2000,
 

--- a/packages/ai-jsx/src/core/errors.ts
+++ b/packages/ai-jsx/src/core/errors.ts
@@ -26,7 +26,6 @@ export enum ErrorCode {
   AnthropicAPIError = 1021,
   ChatModelDoesNotSupportFunctions = 1022,
   ChatCompletionBadInput = 1023,
-  InvalidParamSchemaType = 1024,
 
   ModelOutputDidNotMatchConstraint = 2000,
 

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -422,7 +422,9 @@ export async function* OpenAIChatModel(
     if (delta.content) {
       currentMessage.content = currentMessage.content ?? '';
       currentMessage.content += delta.content;
-      yield delta.content;
+      if (!props.experimental_streamFunctionCallOnly) {
+        yield delta.content;
+      }
     }
     if (delta.function_call) {
       currentMessage.function_call = currentMessage.function_call ?? { name: '', arguments: '' };

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -437,7 +437,7 @@ export async function* OpenAIChatModel(
       if (props.experimental_streamFunctionCallOnly) {
         yield JSON.stringify({
           ...currentMessage.function_call,
-          arguments: untruncateJson.default(currentMessage.function_call.arguments ?? '{}'),
+          arguments: JSON.parse(untruncateJson.default(currentMessage.function_call.arguments || '{}')),
         });
       }
     }
@@ -446,13 +446,16 @@ export async function* OpenAIChatModel(
   logger.debug({ message: currentMessage }, 'Finished createChatCompletion');
 
   if (props.experimental_streamFunctionCallOnly) {
-    return JSON.stringify(currentMessage.function_call);
+    return JSON.stringify({
+      ...currentMessage.function_call,
+      arguments: JSON.parse(currentMessage.function_call?.arguments ?? '{}'),
+    });
   }
   if (currentMessage.function_call) {
     yield (
       <FunctionCall
         name={currentMessage.function_call.name ?? ''}
-        args={JSON.parse(currentMessage.function_call.arguments ?? '{}')}
+        args={JSON.parse(currentMessage.function_call.arguments || '{}')}
       />
     );
   }

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -35,9 +35,8 @@ import GPT3Tokenizer from 'gpt3-tokenizer';
 import { Merge, MergeExclusive } from 'type-fest';
 import { Logger } from '../core/log.js';
 import { HttpError, AIJSXError, ErrorCode } from '../core/errors.js';
-import { getEnvVar } from './util.js';
+import { getEnvVar, patchedUntruncateJson } from './util.js';
 import { ChatOrCompletionModelOrBoth } from './model.js';
-import untruncateJson from 'untruncate-json';
 
 // https://platform.openai.com/docs/models/model-endpoint-compatibility
 type ValidCompletionModel =
@@ -437,7 +436,7 @@ export async function* OpenAIChatModel(
       if (props.experimental_streamFunctionCallOnly) {
         yield JSON.stringify({
           ...currentMessage.function_call,
-          arguments: JSON.parse(untruncateJson.default(currentMessage.function_call.arguments || '{}')),
+          arguments: JSON.parse(patchedUntruncateJson(currentMessage.function_call.arguments || '{}')),
         });
       }
     }

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -410,7 +410,7 @@ export async function* OpenAIChatModel(
     }
   }
 
-  logger.info({ message: currentMessage }, 'Finished createChatCompletion');
+  logger.debug({ message: currentMessage }, 'Finished createChatCompletion');
 
   if (currentMessage.function_call) {
     yield (

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -304,12 +304,6 @@ export async function* OpenAIChatModel(
         'user'
       );
     }
-  } else if (props.experimental_streamFunctionCallOnly) {
-    throw new AIJSXError(
-      'The experimental_streamFunctionCallOnly flag can only be passed when function definitions are also passed.',
-      ErrorCode.ChatCompletionBadInput,
-      'user'
-    );
   }
 
   const messageElements = await render(props.children, {
@@ -436,6 +430,8 @@ export async function* OpenAIChatModel(
       if (props.experimental_streamFunctionCallOnly) {
         yield JSON.stringify({
           ...currentMessage.function_call,
+          // We actually want the argument to be '{}' if it's empty, not '""'.
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           arguments: JSON.parse(patchedUntruncateJson(currentMessage.function_call.arguments || '{}')),
         });
       }
@@ -454,7 +450,7 @@ export async function* OpenAIChatModel(
     yield (
       <FunctionCall
         name={currentMessage.function_call.name ?? ''}
-        args={JSON.parse(currentMessage.function_call.arguments || '{}')}
+        args={JSON.parse(currentMessage.function_call.arguments ?? '{}')}
       />
     );
   }

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -14,6 +14,7 @@ import {
   FunctionDefinition,
   FunctionCall,
   FunctionResponse,
+  getParametersSchema,
 } from '../core/completion.js';
 import { Image, ImageGenPropsWithChildren } from '../core/image-gen.js';
 import {
@@ -355,21 +356,7 @@ export async function* OpenAIChatModel(
     : Object.entries(props.functionDefinitions).map(([functionName, functionDefinition]) => ({
         name: functionName,
         description: functionDefinition.description,
-        parameters: {
-          type: 'object',
-          required: Object.keys(functionDefinition.parameters).filter(
-            (name) => functionDefinition.parameters[name].required
-          ),
-          properties: Object.keys(functionDefinition.parameters).reduce(
-            (map: Record<string, any>, paramName) => ({
-              ...map,
-              [paramName]: {
-                type: functionDefinition.parameters[paramName].type,
-              },
-            }),
-            {}
-          ),
-        },
+        parameters: getParametersSchema(functionDefinition.parameters),
       }));
 
   const openai = getContext(openAiClientContext);
@@ -423,7 +410,7 @@ export async function* OpenAIChatModel(
     }
   }
 
-  logger.debug({ message: currentMessage }, 'Finished createChatCompletion');
+  logger.info({ message: currentMessage }, 'Finished createChatCompletion');
 
   if (currentMessage.function_call) {
     yield (

--- a/packages/ai-jsx/src/lib/util.ts
+++ b/packages/ai-jsx/src/lib/util.ts
@@ -1,3 +1,4 @@
+import untruncateJson from 'untruncate-json';
 import { AIJSXError } from '../core/errors.js';
 
 /** @hidden */
@@ -14,3 +15,9 @@ export function getEnvVar(name: string, shouldThrow: boolean = true) {
   }
   return result;
 }
+
+/**
+ * There's an ESM issue with untruncate-json, so we need to do this to support running on both client & server.
+ */
+/** @hidden */
+export const patchedUntruncateJson = 'default' in untruncateJson ? untruncateJson.default : untruncateJson;

--- a/packages/ai-jsx/src/react/completion.tsx
+++ b/packages/ai-jsx/src/react/completion.tsx
@@ -80,7 +80,7 @@ export async function* UICompletion(
     return <Component>{children.map(toComponent)}</Component>;
   }
 
-  const Element: z.Schema = z.object({
+  const Element: z.ZodObject<any> = z.object({
     name: z.string().refine((c) => Boolean(validComponents[c]), {
       message: `Unknown component "name". Supported components: ${Object.keys(validComponents)}`,
     }),

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -32,5 +32,4 @@ function App() {
   );
 }
 
-// showInspector(<App />);
-console.log(await AI.createRenderContext().render(<App />));
+showInspector(<App />);

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -11,7 +11,7 @@ const FamilyTree: z.Schema = z.array(
   })
 );
 
-const RootFamilyTree: z.Schema = z.object({
+const RootFamilyTree: z.ZodObject<any> = z.object({
   tree: FamilyTree,
 });
 

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -1,3 +1,4 @@
+import * as AI from 'ai-jsx';
 import { UserMessage } from 'ai-jsx/core/completion';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
 import { showInspector } from 'ai-jsx/core/inspector';
@@ -24,11 +25,12 @@ function App() {
       </JsonChatCompletion>
       {'\n\n'}
       YAML generation example:{'\n'}
-      <YamlChatCompletion schema={FamilyTree}>
+      <YamlChatCompletion schema={RootFamilyTree}>
         <UserMessage>{query}</UserMessage>
       </YamlChatCompletion>
     </>
   );
 }
 
-showInspector(<App />);
+// showInspector(<App />);
+console.log(await AI.createRenderContext().render(<App />));

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -19,9 +19,9 @@ function App() {
   return (
     <>
       JSON generation example:{'\n'}
-        <JsonChatCompletion schema={RootFamilyTree}>
-          <UserMessage>{query}</UserMessage>
-        </JsonChatCompletion>
+      <JsonChatCompletion schema={RootFamilyTree}>
+        <UserMessage>{query}</UserMessage>
+      </JsonChatCompletion>
       {'\n\n'}
       YAML generation example:{'\n'}
       <YamlChatCompletion schema={FamilyTree}>

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -1,7 +1,10 @@
-import { UserMessage } from 'ai-jsx/core/completion';
+import { UserMessage, ChatProvider } from 'ai-jsx/core/completion';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
 import { showInspector } from 'ai-jsx/core/inspector';
 import z from 'zod';
+import * as AI from 'ai-jsx';
+import { pino } from 'pino';
+import { PinoLogger } from 'ai-jsx/core/log';
 
 const FamilyTree: z.Schema = z.array(
   z.object({
@@ -10,21 +13,51 @@ const FamilyTree: z.Schema = z.array(
   })
 );
 
+const RootFamilyTree: z.Schema = z.object({
+  tree: FamilyTree,
+});
+
 function App() {
   const query = 'Create a nested family tree with names and ages. It should include a total of 5 people.';
   return (
     <>
       JSON generation example:{'\n'}
-      <JsonChatCompletion schema={FamilyTree}>
-        <UserMessage>{query}</UserMessage>
-      </JsonChatCompletion>
-      {'\n\n'}
+      <ChatProvider model="gpt-4">
+        <JsonChatCompletion schema={RootFamilyTree}>
+          <UserMessage>{query}</UserMessage>
+        </JsonChatCompletion>
+      </ChatProvider>
+      {/* {'\n\n'}
       YAML generation example:{'\n'}
       <YamlChatCompletion schema={FamilyTree}>
         <UserMessage>{query}</UserMessage>
-      </YamlChatCompletion>
+      </YamlChatCompletion> */}
     </>
   );
 }
 
+const pinoStdoutLogger = pino({
+  name: 'ai-jsx',
+  level: process.env.loglevel ?? 'debug',
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true,
+    },
+  },
+});
+
 showInspector(<App />);
+// await AI.createRenderContext({
+//   logger: new PinoLogger(pinoStdoutLogger),
+// }).render(<App />);
+
+// let lastValue = '';
+// const rendering = AI.createRenderContext().render(<App />, { appendOnly: true });
+// for await (const frame of rendering) {
+//   process.stdout.write(frame.slice(lastValue.length));
+//   lastValue = frame;
+// }
+
+// const finalResult = await rendering;
+// process.stdout.write(finalResult.slice(lastValue.length));

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -1,4 +1,3 @@
-import * as AI from 'ai-jsx';
 import { UserMessage } from 'ai-jsx/core/completion';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
 import { showInspector } from 'ai-jsx/core/inspector';

--- a/packages/examples/src/validated-generation.tsx
+++ b/packages/examples/src/validated-generation.tsx
@@ -1,10 +1,7 @@
-import { UserMessage, ChatProvider } from 'ai-jsx/core/completion';
+import { UserMessage } from 'ai-jsx/core/completion';
 import { JsonChatCompletion, YamlChatCompletion } from 'ai-jsx/batteries/constrained-output';
 import { showInspector } from 'ai-jsx/core/inspector';
 import z from 'zod';
-import * as AI from 'ai-jsx';
-import { pino } from 'pino';
-import { PinoLogger } from 'ai-jsx/core/log';
 
 const FamilyTree: z.Schema = z.array(
   z.object({
@@ -22,42 +19,16 @@ function App() {
   return (
     <>
       JSON generation example:{'\n'}
-      <ChatProvider model="gpt-4">
         <JsonChatCompletion schema={RootFamilyTree}>
           <UserMessage>{query}</UserMessage>
         </JsonChatCompletion>
-      </ChatProvider>
-      {/* {'\n\n'}
+      {'\n\n'}
       YAML generation example:{'\n'}
       <YamlChatCompletion schema={FamilyTree}>
         <UserMessage>{query}</UserMessage>
-      </YamlChatCompletion> */}
+      </YamlChatCompletion>
     </>
   );
 }
 
-const pinoStdoutLogger = pino({
-  name: 'ai-jsx',
-  level: process.env.loglevel ?? 'debug',
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-    },
-  },
-});
-
 showInspector(<App />);
-// await AI.createRenderContext({
-//   logger: new PinoLogger(pinoStdoutLogger),
-// }).render(<App />);
-
-// let lastValue = '';
-// const rendering = AI.createRenderContext().render(<App />, { appendOnly: true });
-// for await (const frame of rendering) {
-//   process.stdout.write(frame.slice(lastValue.length));
-//   lastValue = frame;
-// }
-
-// const finalResult = await rendering;
-// process.stdout.write(finalResult.slice(lastValue.length));


### PR DESCRIPTION
This PR creates a version of `JsonChatCompletion` that uses/abuses OpenAI's `FunctionCall`s.
It also expands the definition of a `FunctionParameter` to accept both
the existing simplified version as well as a full-on `z.ZodObject` Schema that
enables more complex scenarios (e.g. recursive types).