### PR TITLE
Use `openai-edge` instead of `@nick.heiner/openai-edge`

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -302,7 +302,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.5.0",
-    "@nick.heiner/openai-edge": "1.0.1-7",
     "@nick.heiner/wandb-fork": "^0.5.2-5",
     "axios": "^1.4.0",
     "cli-highlight": "^2.1.11",
@@ -314,6 +313,7 @@
     "lodash": "^4.17.21",
     "ml-distance": "^4.0.1",
     "openai": "^3.3.0",
+    "openai-edge": "^1.2.0",
     "pino": "^8.14.1",
     "server-only": "^0.0.1",
     "untruncate-json": "^0.0.1",

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -16,18 +16,18 @@ import {
   FunctionResponse,
 } from '../core/completion.js';
 import { Image, ImageGenPropsWithChildren } from '../core/image-gen.js';
-// openai-edge hasn't updated its types to support the new function types yet,
-// so we'll import the types from openai until it does.
-import { ChatCompletionFunctions, ChatCompletionResponseMessage, ChatCompletionRequestMessage } from 'openai';
 import {
   Configuration,
   CreateChatCompletionResponse,
   CreateCompletionResponse,
   OpenAIApi,
+  ChatCompletionFunctions,
+  ChatCompletionResponseMessage,
+  ChatCompletionRequestMessage,
   CreateImageRequestSizeEnum,
   CreateImageRequestResponseFormatEnum,
   ResponseTypes,
-} from '@nick.heiner/openai-edge';
+} from 'openai-edge';
 import * as AI from '../index.js';
 import { PropsOfComponent, Node } from '../index.js';
 import GPT3Tokenizer from 'gpt3-tokenizer';
@@ -385,11 +385,7 @@ export async function* OpenAIChatModel(
   };
 
   logger.debug({ chatCompletionRequest }, 'Calling createChatCompletion');
-  const chatResponse = await openai.createChatCompletion(
-    // We can remove this once openai-edge updates to reflect the new chat function types.
-    // @ts-expect-error
-    chatCompletionRequest
-  );
+  const chatResponse = await openai.createChatCompletion(chatCompletionRequest);
 
   await checkOpenAIResponse(chatResponse, logger, 'createChatCompletion');
 

--- a/packages/tutorial-nextjs/package.json
+++ b/packages/tutorial-nextjs/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@nick.heiner/openai-edge": "1.0.1-7",
     "@types/node": "20.3.1",
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",
@@ -18,6 +17,7 @@
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.6",
     "next": "13.4.6",
+    "openai-edge": "1.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17945,6 +17945,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openai-edge@npm:1.2.0":
+  version: 1.2.0
+  resolution: "openai-edge@npm:1.2.0"
+  checksum: 5fa7962527b4001fe3beb29cb983014b1f7a1051199b4b1df60dc5638b8d31d9f8f8924b7795b997f609cc15cd19f93a64d5e55cd99e5d52a9970acd267e97c9
+  languageName: node
+  linkType: hard
+
 "openai@npm:^3.2.0, openai@npm:^3.3.0":
   version: 3.3.0
   resolution: "openai@npm:3.3.0"
@@ -22716,7 +22723,6 @@ __metadata:
     "@babel/core": ^7.22.5
     "@babel/plugin-transform-react-jsx": ^7.22.5
     "@next/eslint-plugin-next": ^13.4.6
-    "@nick.heiner/openai-edge": 1.0.1-7
     "@types/node": 20.3.1
     "@types/react": 18.2.12
     "@types/react-dom": 18.2.5
@@ -22728,6 +22734,7 @@ __metadata:
     eslint-config-next: 13.4.6
     eslint-config-nth: ^2.0.1
     next: 13.4.6
+    openai-edge: 1.2.0
     react: 18.2.0
     react-dom: 18.2.0
     typescript: 5.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,13 +3946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nick.heiner/openai-edge@npm:1.0.1-7":
-  version: 1.0.1-7
-  resolution: "@nick.heiner/openai-edge@npm:1.0.1-7"
-  checksum: f53e39082901018113353c1c4b8ecddc1465a4355b7c8721a309d9243d58310c78c86af11c30c1ae2a767b6636f2e02cdc78d00144fefa81d7818916253637a1
-  languageName: node
-  linkType: hard
-
 "@nick.heiner/wandb-fork@npm:^0.5.2-5":
   version: 0.5.2-5
   resolution: "@nick.heiner/wandb-fork@npm:0.5.2-5"
@@ -7559,7 +7552,6 @@ __metadata:
   dependencies:
     "@anthropic-ai/sdk": ^0.5.0
     "@jest/globals": ^29.5.0
-    "@nick.heiner/openai-edge": 1.0.1-7
     "@nick.heiner/wandb-fork": ^0.5.2-5
     "@tsconfig/node16": ^1.0.4
     "@tsconfig/node18": ^2.0.1
@@ -7591,6 +7583,7 @@ __metadata:
     ml-distance: ^4.0.1
     node-fetch: ^3.3.1
     openai: ^3.3.0
+    openai-edge: ^1.2.0
     pino: ^8.14.1
     pino-pretty: ^10.0.0
     react: ^18.2.0
@@ -17945,7 +17938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai-edge@npm:1.2.0":
+"openai-edge@npm:1.2.0, openai-edge@npm:^1.2.0":
   version: 1.2.0
   resolution: "openai-edge@npm:1.2.0"
   checksum: 5fa7962527b4001fe3beb29cb983014b1f7a1051199b4b1df60dc5638b8d31d9f8f8924b7795b997f609cc15cd19f93a64d5e55cd99e5d52a9970acd267e97c9


### PR DESCRIPTION
Thanks for the report. We were using a fork of `openai-edge` to work around this issue: https://github.com/dan-kwiat/openai-edge/issues/6. However, that issue is now resolved.