### PR TITLE
Add DocsQAWithSources component

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -4,19 +4,19 @@
  * @packageDocumentation
  */
 
-import * as AI from '../index.js';
-import {
-  ChatCompletion,
-  SystemMessage,
-  AssistantMessage,
-  UserMessage,
-  ModelPropsWithChildren,
-} from '../core/completion.js';
 import yaml from 'js-yaml';
-import { AIJSXError, ErrorCode, ErrorBlame } from '../core/errors.js';
 import { Jsonifiable } from 'type-fest';
 import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  AssistantMessage,
+  ChatCompletion,
+  ModelPropsWithChildren,
+  SystemMessage,
+  UserMessage,
+} from '../core/completion.js';
+import { AIJSXError, ErrorBlame, ErrorCode } from '../core/errors.js';
+import * as AI from '../index.js';
 import { patchedUntruncateJson } from '../lib/util.js';
 
 export type ObjectCompletion = ModelPropsWithChildren & {
@@ -315,6 +315,7 @@ export async function* JsonChatCompletionFunctionCall(
           parameters: schema,
         },
       }}
+      forcedFunction="print"
     >
       {children}
       <SystemMessage>

--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -828,7 +828,7 @@ function DefaultQAResultFormatter(result: QAWithCitationsResult) {
 }
 
 /**
- * Similar to {@link DocsQA}, but encourages the LLM to return sources for its answer.
+ * Similar to {@link DocsQA}, but encourages the LLM to return citations for its answer.
  */
 export async function* DocsQAWithCitations<ChunkMetadata extends Jsonifiable = Jsonifiable>(
   props: DocsQAWithCitationsProps<ChunkMetadata>,

--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -807,10 +807,12 @@ export async function DocsQA<ChunkMetadata extends Jsonifiable = Jsonifiable>(pr
   );
 }
 
-const ResultSchema: z.ZodObject<any> = z.object({
-  answer: z.string().describe("The answer to the user's question"),
-  sources: z.array(z.string()).describe('The title or URL of each document used to answer the question'),
-}).required({answer: true});
+const ResultSchema: z.ZodObject<any> = z
+  .object({
+    answer: z.string().describe("The answer to the user's question"),
+    sources: z.array(z.string()).describe('The title or URL of each document used to answer the question'),
+  })
+  .required({ answer: true });
 
 export type QAWithSourcesResult = z.infer<typeof ResultSchema>;
 
@@ -827,7 +829,8 @@ function DefaultQAResultFormatter(result: QAWithSourcesResult) {
  */
 export async function* DocsQAWithSources<ChunkMetadata extends Jsonifiable = Jsonifiable>(
   props: DocsQAProps<ChunkMetadata>,
-  { render }: AI.ComponentContext) {
+  { render }: AI.ComponentContext
+) {
   const chunks = await props.corpus.search(props.question, { limit: props.chunkLimit });
   const chunkFormatter: (props: { doc: ScoredChunk<ChunkMetadata> }) => Node = props.chunkFormatter ?? DefaultFormatter;
   const resultFormatter: (result: QAWithSourcesResult) => Node = props.resultFormatter ?? DefaultQAResultFormatter;

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -317,18 +317,12 @@ export async function* OpenAIChatModel(
     );
   }
 
-  if (props.forcedFunction) {
-    if (
-      !Object.entries(props.functionDefinitions)
-        .map(([functionName, _]) => functionName)
-        .find((f) => f == props.forcedFunction)
-    ) {
-      throw new AIJSXError(
-        `The function ${props.forcedFunction} was forced, but no function with that name was defined.`,
-        ErrorCode.ChatCompletionBadInput,
-        'user'
-      );
-    }
+  if (props.forcedFunction && !Object.keys(props.functionDefinitions).includes(props.forcedFunction)) {
+    throw new AIJSXError(
+      `The function ${props.forcedFunction} was forced, but no function with that name was defined.`,
+      ErrorCode.ChatCompletionBadInput,
+      'user'
+    );
   }
 
   const messageElements = await render(props.children, {
@@ -401,11 +395,9 @@ export async function* OpenAIChatModel(
         description: functionDefinition.description,
         parameters: getParametersSchema(functionDefinition.parameters),
       }));
-  const openaiFunctionCall: CreateChatCompletionRequestFunctionCall | undefined = !props.forcedFunction
-    ? undefined
-    : {
-        name: props.forcedFunction,
-      };
+  const openaiFunctionCall: CreateChatCompletionRequestFunctionCall | undefined = props.forcedFunction
+    ? { name: props.forcedFunction }
+    : undefined;
 
   const openai = getContext(openAiClientContext);
   const chatCompletionRequest = {

--- a/packages/docs/docs/guides/docsqa.md
+++ b/packages/docs/docs/guides/docsqa.md
@@ -118,11 +118,10 @@ The `DocsQA` component provides an answer, like:
 */
 ```
 
-If you want an answer that cites sources, use `DocsQAWithSources`:
+If you want an answer that cites sources, use `DocsQAWithCitations`:
 
 ```tsx
-<DocsQAWithSources question="What is the atomic number of nitrogen?" 
-  corpus={corpus} docComponent={ShowDoc} />
+<DocsQAWithCitations question="What is the atomic number of nitrogen?" corpus={corpus} docComponent={ShowDoc} />
 /* Renders:
     Nitogen's atomic number is 7
     Sources: https://en.wikipedia.org/wiki/Nitrogen
@@ -132,22 +131,32 @@ If you want an answer that cites sources, use `DocsQAWithSources`:
 If you want to customize how the citations are formatted, pass a `resultsFormatter`:
 
 ```tsx
-function ResultFormatter(result: QAWithSourcesResult) {
-  return <>
-    {result.answer}
-    {result.sources.length && <>
-      Learn more:{'\n'}
-      {result.sources.map(source => <>* {source}{'\n'}</>)}
-    </>}
-  </>
+function ResultFormatter(result: QAWithCitationsResult) {
+  return (
+    <>
+      {result.answer}
+      {result.sources.length && (
+        <>
+          Learn more:{'\n'}
+          {result.sources.map((source) => (
+            <>
+              * {source}
+              {'\n'}
+            </>
+          ))}
+        </>
+      )}
+    </>
+  );
 }
 
-<DocsQAWithSources 
+<DocsQAWithCitations
   question="What is the atomic number of nitrogen?"
-  corpus={corpus} docComponent={ShowDoc}
+  corpus={corpus}
+  docComponent={ShowDoc}
   // highlight-next-line
   resultFormatter={ResultFormatter}
-/>
+/>;
 /* Renders:
     Nitogen's atomic number is 7
     Learn more:

--- a/packages/docs/docs/guides/docsqa.md
+++ b/packages/docs/docs/guides/docsqa.md
@@ -86,7 +86,7 @@ flowchart LR
   que[Query] -->|string| embed2[Embed] -->|vector| vdb2[(Vector DB)] -->|similar chunks| LLM
 ```
 
-If you use the built-in DocsQA tag from AI.JSX, then you just need to decide how to present the chunk to your LLM:
+If you use the built-in `DocsQA` component from AI.JSX, then you just need to decide how to present the chunk to your LLM:
 
 ```typescript
 function ShowDoc({ doc }: { doc: Document<MyDocMetadata> }) {
@@ -107,6 +107,52 @@ function AskAndAnswer({ query }: { query: string }) {
     </>
   );
 }
+```
+
+The `DocsQA` component provides an answer, like:
+
+```tsx
+<DocsQA question="What is the atomic number of nitrogen?" corpus={corpus} docComponent={ShowDoc} />
+/* Renders:
+    Nitogen's atomic number is 7
+*/
+```
+
+If you want an answer that cites sources, use `DocsQAWithSources`:
+
+```tsx
+<DocsQAWithSources question="What is the atomic number of nitrogen?" 
+  corpus={corpus} docComponent={ShowDoc} />
+/* Renders:
+    Nitogen's atomic number is 7
+    Sources: https://en.wikipedia.org/wiki/Nitrogen
+*/
+```
+
+If you want to customize how the citations are formatted, pass a `resultsFormatter`:
+
+```tsx
+function ResultFormatter(result: QAWithSourcesResult) {
+  return <>
+    {result.answer}
+    {result.sources.length && <>
+      Learn more:{'\n'}
+      {result.sources.map(source => <>* {source}{'\n'}</>)}
+    </>}
+  </>
+}
+
+<DocsQAWithSources 
+  question="What is the atomic number of nitrogen?"
+  corpus={corpus} docComponent={ShowDoc}
+  // highlight-next-line
+  resultFormatter={ResultFormatter}
+/>
+/* Renders:
+    Nitogen's atomic number is 7
+    Learn more:
+    * https://en.wikipedia.org/wiki/Nitrogen
+*/
 ```
 
 ## Picking a Corpus Implementation

--- a/packages/docs/docs/guides/docsqa.md
+++ b/packages/docs/docs/guides/docsqa.md
@@ -86,7 +86,7 @@ flowchart LR
   que[Query] -->|string| embed2[Embed] -->|vector| vdb2[(Vector DB)] -->|similar chunks| LLM
 ```
 
-If you use the built-in `DocsQA` component from AI.JSX, then you just need to decide how to present the chunk to your LLM:
+If you use the built-in [`DocsQA`](../api/modules/batteries_docs.md#docsqa) component from AI.JSX, then you just need to decide how to present the chunk to your LLM:
 
 ```typescript
 function ShowDoc({ doc }: { doc: Document<MyDocMetadata> }) {
@@ -118,7 +118,7 @@ The `DocsQA` component provides an answer, like:
 */
 ```
 
-If you want an answer that cites sources, use `DocsQAWithCitations`:
+If you want an answer that cites sources, use [`DocsQAWithCitations`](../api/modules/batteries_docs.md#docsqawithcitations):
 
 ```tsx
 <DocsQAWithCitations question="What is the atomic number of nitrogen?" corpus={corpus} docComponent={ShowDoc} />

--- a/packages/tutorial/src/docsqa.tsx
+++ b/packages/tutorial/src/docsqa.tsx
@@ -1,8 +1,8 @@
 import {
   DocsQA,
-  DocsQAWithSources,
+  DocsQAWithCitations,
   LocalCorpus,
-  QAWithSourcesResult,
+  QAWithCitationsResult,
   ScoredChunk,
   makeChunker,
   staticLoader,
@@ -30,15 +30,15 @@ function OptionalCustomChunkFormatter({ doc }: { doc: ScoredChunk }) {
    * This presents document chunks as a simple string with the chunk's contents instead of
    * formatting it with metadata like a title.
    *
-   * Note that not including a title makes it difficult to use DocsQAWithSources since the LLM
+   * Note that not including a title makes it difficult to use DocsQAWithCitations since the LLM
    * won't know how to refer to this doc.
    */
   return doc.chunk.content;
 }
 
-function OptionalCustomResultFormatter(result: QAWithSourcesResult) {
+function OptionalCustomResultFormatter(result: QAWithCitationsResult) {
   /**
-   * The formats the result of a DocsQAWithSources call to present the answer and sources as
+   * The formats the result of a DocsQAWithCitations call to present the answer and sources as
    * desired.
    */
   const linkedSources =
@@ -47,7 +47,7 @@ function OptionalCustomResultFormatter(result: QAWithSourcesResult) {
         return `<a href="${URL}">${source}</a>`;
       }
       return source;
-    }) || [];
+    }) ?? [];
 
   if (linkedSources.length) {
     return `${result.answer} (from ${linkedSources.join(', ')})`;
@@ -58,16 +58,19 @@ function OptionalCustomResultFormatter(result: QAWithSourcesResult) {
 function App() {
   return (
     <>
-      <DocsQAWithSources question="What was Hurricane Katrina?" corpus={corpus} chunkLimit={5} />
-      {'\n\n'}
+      DocsQA without source citations:{'\n'}
       <DocsQA
-        question="Which dates did the storm occur?"
+        question="Which dates did the Huricane Katrina occur?"
         corpus={corpus}
         chunkLimit={5}
         chunkFormatter={OptionalCustomChunkFormatter}
       />
       {'\n\n'}
-      <DocsQAWithSources
+      DocsQA with source citations:{'\n'}
+      <DocsQAWithCitations question="What was Hurricane Katrina?" corpus={corpus} chunkLimit={5} />
+      {'\n\n'}
+      DocsQA with source citations and custom result formatter:{'\n'}
+      <DocsQAWithCitations
         question="Where were the strongest winds reported?"
         corpus={corpus}
         chunkLimit={5}

--- a/packages/tutorial/src/docsqa.tsx
+++ b/packages/tutorial/src/docsqa.tsx
@@ -1,4 +1,4 @@
-import { DocsQA, LocalCorpus, ScoredChunk, makeChunker, staticLoader } from 'ai-jsx/batteries/docs';
+import { DocsQA, DocsQAWithSources, LocalCorpus, ScoredChunk, makeChunker, staticLoader } from 'ai-jsx/batteries/docs';
 import { showInspector } from 'ai-jsx/core/inspector';
 import fetch from 'node-fetch';
 import TurndownService from 'turndown';
@@ -17,22 +17,28 @@ const docs = [
 const corpus = new LocalCorpus(staticLoader(docs), makeChunker(600, 100));
 await corpus.load();
 
-function GetChunk({ doc }: { doc: ScoredChunk }) {
+function OptionalCustomFormatter({ doc }: { doc: ScoredChunk }) {
+  /**
+   * This presents document chunks as a simple string with the chunk's contents instead of
+   * formatting it with metadata like a title.
+   *
+   * Note that not including a title makes it difficult to use DocsQAWithSources since the LLM
+   * won't know how to refer to this doc.
+   */
   return doc.chunk.content;
 }
 
 function App() {
   return (
     <>
-      <DocsQA question="What was Hurricane Katrina?" corpus={corpus} chunkLimit={5} chunkFormatter={GetChunk} />
+      <DocsQAWithSources question="What was Hurricane Katrina?" corpus={corpus} chunkLimit={5} />
       {'\n\n'}
-      <DocsQA question="Which dates did the storm occur?" corpus={corpus} chunkLimit={5} chunkFormatter={GetChunk} />
+      <DocsQA question="Which dates did the storm occur?" corpus={corpus} chunkLimit={5} chunkFormatter={OptionalCustomFormatter}/>
       {'\n\n'}
-      <DocsQA
+      <DocsQAWithSources
         question="Where were the strongest winds reported?"
         corpus={corpus}
         chunkLimit={5}
-        chunkFormatter={GetChunk}
       />
     </>
   );

--- a/packages/tutorial/src/docsqa.tsx
+++ b/packages/tutorial/src/docsqa.tsx
@@ -1,4 +1,12 @@
-import { DocsQA, DocsQAWithSources, LocalCorpus, QAWithSourcesResult, ScoredChunk, makeChunker, staticLoader } from 'ai-jsx/batteries/docs';
+import {
+  DocsQA,
+  DocsQAWithSources,
+  LocalCorpus,
+  QAWithSourcesResult,
+  ScoredChunk,
+  makeChunker,
+  staticLoader,
+} from 'ai-jsx/batteries/docs';
 import { showInspector } from 'ai-jsx/core/inspector';
 import fetch from 'node-fetch';
 import TurndownService from 'turndown';
@@ -33,12 +41,13 @@ function OptionalCustomResultFormatter(result: QAWithSourcesResult) {
    * The formats the result of a DocsQAWithSources call to present the answer and sources as
    * desired.
    */
-  const linkedSources = result.sources?.map((source: string) => {
-    if (source == 'Wikipedia Article about Hurricane Katrina') {
-      return `<a href="${URL}">${source}</a>`;
-    }
-    return source;
-  }) || [];
+  const linkedSources =
+    result.sources?.map((source: string) => {
+      if (source == 'Wikipedia Article about Hurricane Katrina') {
+        return `<a href="${URL}">${source}</a>`;
+      }
+      return source;
+    }) || [];
 
   if (linkedSources.length) {
     return `${result.answer} (from ${linkedSources.join(', ')})`;
@@ -51,7 +60,12 @@ function App() {
     <>
       <DocsQAWithSources question="What was Hurricane Katrina?" corpus={corpus} chunkLimit={5} />
       {'\n\n'}
-      <DocsQA question="Which dates did the storm occur?" corpus={corpus} chunkLimit={5} chunkFormatter={OptionalCustomChunkFormatter}/>
+      <DocsQA
+        question="Which dates did the storm occur?"
+        corpus={corpus}
+        chunkLimit={5}
+        chunkFormatter={OptionalCustomChunkFormatter}
+      />
       {'\n\n'}
       <DocsQAWithSources
         question="Where were the strongest winds reported?"

--- a/packages/tutorial/src/docsqa.tsx
+++ b/packages/tutorial/src/docsqa.tsx
@@ -60,7 +60,7 @@ function App() {
     <>
       DocsQA without source citations:{'\n'}
       <DocsQA
-        question="Which dates did the Huricane Katrina occur?"
+        question="Which dates did the Hurricane Katrina occur?"
         corpus={corpus}
         chunkLimit={5}
         chunkFormatter={OptionalCustomChunkFormatter}


### PR DESCRIPTION
This extends on DocsQA by encouraging the LLM to provide sources for its answer and allowing the developer to format the result as they like.