### PR TITLE
Allow UseTools to augment a broader conversation

### DIFF
--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -5,6 +5,7 @@
  */
 
 import {
+  AssistantMessage,
   ChatCompletion,
   FunctionCall,
   FunctionParameters,
@@ -12,10 +13,11 @@ import {
   SystemMessage,
   UserMessage,
 } from '../core/completion.js';
-import { Node, RenderContext, isElement, Element } from '../index.js';
+import { Node, RenderContext, isElement, Element, AppendOnlyStream, RenderableStream } from '../index.js';
 import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
+import { memo } from '../core/memoize.js';
 
 const toolChoiceSchema = z.object({
   nameOfTool: z.string(),
@@ -24,7 +26,7 @@ const toolChoiceSchema = z.object({
 });
 export type ToolChoice = z.infer<typeof toolChoiceSchema> | null;
 
-function ChooseTools(props: Pick<UseToolsProps, 'tools' | 'userData' | 'query'>): Node {
+function ChooseTools(props: Pick<UseToolsProps, 'tools' | 'userData' | 'children'>): Node {
   return (
     <ChatCompletion>
       <SystemMessage>
@@ -43,7 +45,7 @@ function ChooseTools(props: Pick<UseToolsProps, 'tools' | 'userData' | 'query'>)
         If none of the tools seem appropriate, or the user data doesn't have the necessary context to use the tool the
         user needs, respond with `null`.
       </SystemMessage>
-      <UserMessage>Generate a JSON response for this query: {props.query}</UserMessage>
+      <UserMessage>Generate a JSON response for this query: {props.children}</UserMessage>
     </ChatCompletion>
   );
 }
@@ -127,9 +129,14 @@ export interface UseToolsProps {
   tools: Record<string, Tool>;
 
   /**
-   * A query the AI will use to decide which tool to use, and what parameters to invoke it with.
+   * The conversation in which the AI can use a tool.
    */
-  query: string;
+  children: Node;
+
+  /**
+   * Whether the result should include intermediate steps, for example, the execution of the function and its response.
+   */
+  showSteps?: boolean;
 
   /**
    * A fallback response to use if the AI doesn't think any of the tools are relevant.
@@ -203,30 +210,31 @@ export async function* UseTools(props: UseToolsProps, { render }: RenderContext)
 }
 
 /** @hidden */
-export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: RenderContext) {
-  const messages = [
-    <SystemMessage>You are a smart agent that may use functions to answer a user question.</SystemMessage>,
-  ];
-  if (props.fallback) {
-    messages.push(
-      <SystemMessage>Here's the fallback strategy/message if something failed: {props.fallback}</SystemMessage>
-    );
-  }
-  messages.push(<UserMessage>{props.query}</UserMessage>);
+export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: RenderContext): RenderableStream {
+  yield AppendOnlyStream;
+
+  const conversation = [memo(props.children)];
 
   do {
-    const modelResponse = <ChatCompletion functionDefinitions={props.tools}>{messages}</ChatCompletion>;
+    const modelResponse = memo(<ChatCompletion functionDefinitions={props.tools}>{conversation}</ChatCompletion>);
+    if (props.showSteps) {
+      yield modelResponse;
+    }
 
-    const renderResult = yield* render(modelResponse, { stop: (el) => el.tag == FunctionCall });
-
-    const stringResponses: String[] = [];
+    const renderResult = await render(modelResponse, { stop: (el) => el.tag == FunctionCall });
     let functionCallElement: Element<any> | null = null;
 
+    let currentString = '';
     for (const element of renderResult) {
       if (typeof element === 'string') {
         // Model has generated a string response. Record it.
-        stringResponses.push(element);
-      } else if (isElement(element)) {
+        currentString += element;
+      } else if (isElement(element) && element.tag === FunctionCall) {
+        if (currentString.trim() !== '') {
+          conversation.push(<AssistantMessage>{currentString}</AssistantMessage>);
+          currentString = '';
+        }
+
         // Model has generated a function call.
         if (functionCallElement) {
           throw new AIJSXError(
@@ -235,6 +243,7 @@ export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: Re
             'runtime'
           );
         }
+        conversation.push(memo(element));
         functionCallElement = element;
       } else {
         throw new AIJSXError(
@@ -246,8 +255,6 @@ export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: Re
     }
 
     if (functionCallElement) {
-      messages.push(functionCallElement);
-      yield functionCallElement;
       // Call the selected function and append the result to the messages.
       let response;
       try {
@@ -256,15 +263,32 @@ export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: Re
       } catch (e: any) {
         response = `Function called failed with error: ${e.message}.`;
       } finally {
-        const functionResponse = <FunctionResponse name={functionCallElement.props.name}>{response}</FunctionResponse>;
-        yield functionResponse;
-        messages.push(functionResponse);
+        const functionResponse = memo(
+          <FunctionResponse name={functionCallElement.props.name}>{response}</FunctionResponse>
+        );
+        if (props.showSteps) {
+          yield (
+            <>
+              {'\n'}
+              {functionResponse}
+              {'\n'}
+            </>
+          );
+        }
+        conversation.push(functionResponse);
       }
-    } else {
-      // Model did not generate any function call. Return the string responses.
-      return stringResponses.join('');
+
+      continue;
     }
+
+    // Terminate the loop when the model produces a response without a function call.
+    if (!props.showSteps) {
+      yield modelResponse;
+    }
+    break;
   } while (true);
+
+  return AppendOnlyStream;
 }
 
 /** @hidden */

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -1,6 +1,7 @@
 import * as math from 'mathjs';
 import { UseTools, Tool } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
+import { UserMessage } from 'ai-jsx/core/completion';
 
 function evaluate({ expression }: { expression: string }) {
   return math.evaluate(expression);
@@ -20,7 +21,11 @@ function App({ query }: { query: string }) {
       func: evaluate,
     },
   };
-  return <UseTools tools={tools} query={query} fallback="Failed to evaluate the mathematical expression" />;
+  return (
+    <UseTools showSteps tools={tools} fallback="Failed to evaluate the mathematical expression">
+      <UserMessage>{query}</UserMessage>
+    </UseTools>
+  );
 }
 
 showInspector(<App query="What is 2523231 * 2382382?" />);


### PR DESCRIPTION
This allows `<UseTools>` (specifically when using a `<ChatCompletion>` that supports function calls) to drive the function-calling loop as part of existing conversation.  That is, it now accepts a full conversation and invokes functions/appends to the conversation as the model requests.

It also adds a `showSteps` parameter which allows for streaming by also streaming the intermediate steps. Without this, we don't know whether an assistant message is terminal until it's fully rendered. (I suspect we'll iterate on the presentation of these intermediate steps shortly.)