### PR TITLE
Make logging controllable via environment variable

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -139,7 +139,8 @@ export interface UseToolsProps {
   showSteps?: boolean;
 
   /**
-   * A fallback response to use if the AI doesn't think any of the tools are relevant.
+   * A fallback response to use if the AI doesn't think any of the tools are relevant. This is only used for models that do not support functions natively. Models that support functions natively don't need this, because they generate
+   * their own messages in the case of failure.
    */
   fallback: Node;
 

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -71,10 +71,12 @@ export class NoOpLogImplementation extends LogImplementation {
   log(): void {}
 }
 
-const defaultPinoLogger = _.once(() =>
+const defaultPinoLogger = _.once(() => {
+  const logEnv = process.env.AIJSX_LOG ?? 'silent';
+  const [level, file] = logEnv.split(':', 2);
   // @ts-expect-error
-  pino({ name: 'ai-jsx', level: 'info' })
-);
+  return pino({ name: 'ai-jsx', level }, (file && pino.destination(file)) ?? undefined);
+});
 
 /**
  * An implementation of {@link LogImplementation} that uses the `pino` logging library.

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -75,7 +75,7 @@ const defaultPinoLogger = _.once(() => {
   const logEnv = process.env.AIJSX_LOG ?? 'silent';
   const [level, file] = logEnv.split(':', 2);
   // @ts-expect-error
-  return pino({ name: 'ai-jsx', level }, (file && pino.destination(file)) ?? undefined);
+  return pino({ name: 'ai-jsx', level }, file && pino.destination(file));
 });
 
 /**

--- a/packages/ai-jsx/src/inspector/console.tsx
+++ b/packages/ai-jsx/src/inspector/console.tsx
@@ -8,7 +8,6 @@ import Spinner from './spinner.js';
 import { DebugTree } from '../core/debug.js';
 
 import { Box, render, Spacer, Text, useInput, useStdout } from 'ink';
-import { NoOpLogImplementation } from '../core/log.js';
 
 /** Get the size of the terminal window. */
 export function useStdoutDimensions(): [number, number] {
@@ -87,7 +86,7 @@ function Inspector({ componentToInspect, showDebugTree }: { componentToInspect: 
   const pushDebugTreeStep = (step: string) => setDebugTreeSteps((previous) => previous.concat([step]));
 
   useEffect(() => {
-    const renderContext = AI.createRenderContext({ logger: new NoOpLogImplementation() });
+    const renderContext = AI.createRenderContext();
     const memoized = memo(componentToInspect);
 
     async function getAllFrames() {

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.6.0
+## 0.6.1
+
+- Add `AIJSX_LOG` environment variable to control log level and output location.
+
+## [0.6.0](https://github.com/fixie-ai/ai-jsx/commit/7fce0f4ae4eca4d2679177ecb357cd60699e3913)
 
 - Update `<UseTools>` to take a complete conversation as a `children` prop, rather than as a string `query` prop.
 

--- a/packages/docs/docs/guides/observability.md
+++ b/packages/docs/docs/guides/observability.md
@@ -26,33 +26,13 @@ This produces no logging.
 
 ## Console Logging of LLM Calls
 
-Now to add logging to the console, we will add two lines of code:
+To log to the console, set the `AIJSX_LOG` environment variable to the desired log level (for example `"info"` or `"debug"`).
 
-```tsx file="index.tsx"
-import * as AI from 'ai-jsx';
-import { ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completion';
-// highlight-next-line
-import { PinoLogger } from 'ai-jsx/core/log';
-import pino from 'pino';
-
-function App() {
-  return (
-    <ChatCompletion>
-      <SystemMessage>You are an agent that only asks rhetorical questions.</SystemMessage>
-      <UserMessage>How can I learn about Ancient Egypt?</UserMessage>
-    </ChatCompletion>
-  );
-}
-
-console.log(
-  await AI.createRenderContext({
-    // highlight-next-line
-    logger: new PinoLogger(pino({ level: 'debug' })), //default level is 'info'
-  }).render(<App />)
-);
+```sh
+AIJSX_LOG=debug node ./my-ai-jsx-program.tsx
 ```
 
-The first line we added is where we import our logger. See [`PinoLogger`](/api/classes/core_log.PinoLogger) to learn more. In the second line, we instantiate and use the logger. Now, when you run the code, you should see something like this on the console:
+Now you should see JSON log events written to the console, such as
 
 ```json
 {
@@ -75,80 +55,23 @@ The first line we added is where we import our logger. See [`PinoLogger`](/api/c
 }
 ```
 
-To view this in a nicer way, pipe the console output to `pino-pretty`: `node ./my-ai-jsx-program.tsx | npx pino-pretty`:
+To view this in a nicer way, pipe the console output to `pino-pretty`:
 
-```
-[12:05:39.756] DEBUG (ai-jsx/57473): Calling createChatCompletion
-    chatCompletionRequest: {
-      "model": "gpt-3.5-turbo",
-      "messages": [
-        {
-          "role": "system",
-          "content": "You are an agent that only asks rhetorical questions."
-        },
-        {
-          "role": "user",
-          "content": "How can I learn about Ancient Egypt?"
-        }
-      ],
-      "stream": true
-    }
-    renderId: "6ce9175d-2fbd-4651-a72f-fa0764a9c4c2"
-    element: "<OpenAIChatModel>"
+```sh
+AIJSX_LOG=debug node ./my-ai-jsx-program.tsx | npx pino-pretty
 ```
 
 `pino-pretty` has a number of [options](https://github.com/pinojs/pino-pretty#cli-arguments) you can use to further configure how you view the logs.
 
 You can use `grep` to filter the log to just the events or loglevels you care about.
 
-:::note NextJS
+You may also specify a file for log events as well by putting a path after level, separated by ':' charatcer:
 
-When using NextJS, instead of specifying a logger in `createRenderContext`, you can pass one to the props of your `<AI.JSX>` tag.
-
-:::
-
-### Custom Pino Logging
-
-If you want to customize the log sources further, you can create your own `pino` logger instance:
-
-```tsx file="index.tsx"
-import * as AI from 'ai-jsx';
-import { ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completion';
-import { PinoLogger } from 'ai-jsx/core/log';
-// highlight-next-line
-import { pino } from 'pino';
-
-function App() {
-  return (
-    <ChatCompletion>
-      <SystemMessage>You are an agent that only asks rhetorical questions.</SystemMessage>
-      <UserMessage>How can I learn about Ancient Egypt?</UserMessage>
-    </ChatCompletion>
-  );
-}
-
-// highlight-start
-const pinoStdoutLogger = pino({
-  name: 'my-project',
-  level: process.env.loglevel ?? 'debug',
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-    },
-  },
-});
-// highlight-end
-
-console.log(
-  await AI.createRenderContext({
-    // highlight-next-line
-    logger: new PinoLogger(pinoStdoutLogger),
-  }).render(<App />)
-);
+```sh
+AIJSX_LOG=debug:/tmp/ai-jsx.log node ./my-ai-jsx-program.tsx
 ```
 
-When you run this, you'll see `pino-pretty`-formatted logs on stdout. See `pino`'s other [options](https://github.com/pinojs/pino) for further ways you can configure the logging.
+Now logs will be written to `/tmp/ai-jsx.log`.
 
 ### Fully Custom Logging
 

--- a/packages/docs/docs/guides/observability.md
+++ b/packages/docs/docs/guides/observability.md
@@ -65,13 +65,13 @@ AIJSX_LOG=debug node ./my-ai-jsx-program.tsx | npx pino-pretty
 
 You can use `grep` to filter the log to just the events or loglevels you care about.
 
-You may also specify a file for log events as well by putting a path after level, separated by ':' charatcer:
+You may also specify a file for log events as well by putting a path after level, separated by ':' character:
 
 ```sh
 AIJSX_LOG=debug:/tmp/ai-jsx.log node ./my-ai-jsx-program.tsx
 ```
 
-Now logs will be written to `/tmp/ai-jsx.log`.
+Now logs will be appended to `/tmp/ai-jsx.log`.
 
 ### Fully Custom Logging
 
@@ -93,6 +93,18 @@ log(
   message?: string
 ): void;
 ```
+
+A custom `LogImplementation` can be passed to `createRenderContext` via the `logger` option:
+
+```ts
+AI.createRenderContext({ logger: new CustomLogImplementation() });
+```
+
+:::note NextJS
+
+When using NextJS, instead of specifying a logger in `createRenderContext`, you can pass one to the props of your `<AI.JSX>` tag.
+
+:::
 
 ## Producing Logs
 


### PR DESCRIPTION
This changes the default logger to support an `AIJSX_LOG` environment variable that can specify a log level (`AIJSX_LOG=debug`) and optionally an output file (`AIJSX_LOG=debug:/tmp/ai-jsx.log`).