### PR TITLE
Move memo to RenderContext

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "volta": {
     "extends": "../../package.json"
   },
@@ -124,15 +124,6 @@
       },
       "require": {
         "default": "./dist/cjs/core/log.cjs"
-      }
-    },
-    "./core/memoize": {
-      "import": {
-        "types": "./dist/esm/core/memoize.d.ts",
-        "default": "./dist/esm/core/memoize.js"
-      },
-      "require": {
-        "default": "./dist/cjs/core/memoize.cjs"
       }
     },
     "./core/inspector": {

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -13,11 +13,18 @@ import {
   SystemMessage,
   UserMessage,
 } from '../core/completion.js';
-import { Node, RenderContext, isElement, Element, AppendOnlyStream, RenderableStream } from '../index.js';
+import {
+  Node,
+  RenderContext,
+  isElement,
+  Element,
+  AppendOnlyStream,
+  ComponentContext,
+  RenderableStream,
+} from '../index.js';
 import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
-import { memo } from '../core/memoize.js';
 
 const toolChoiceSchema = z.object({
   nameOfTool: z.string(),
@@ -212,7 +219,10 @@ export async function* UseTools(props: UseToolsProps, { render }: RenderContext)
 }
 
 /** @hidden */
-export async function* UseToolsFunctionCall(props: UseToolsProps, { render }: RenderContext): RenderableStream {
+export async function* UseToolsFunctionCall(
+  props: UseToolsProps,
+  { render, memo }: ComponentContext
+): RenderableStream {
   yield AppendOnlyStream;
 
   const conversation = [memo(props.children)];

--- a/packages/ai-jsx/src/core/inline.tsx
+++ b/packages/ai-jsx/src/core/inline.tsx
@@ -1,5 +1,4 @@
-import { Node } from '../index.js';
-import { memo } from './memoize.js';
+import { ComponentContext, Node } from '../index.js';
 
 type InlineFn = (prefix: Node) => Node;
 type InlineChild = Node | InlineFn;
@@ -42,7 +41,7 @@ type InlineChildren = InlineChild | InlineChildren[];
  *
  * For more details, see [this example code](https://github.com/fixie-ai/ai-jsx/blob/main/packages/tutorial/src/part2.tsx).
  */
-export function Inline(props: { children: InlineChildren }) {
+export function Inline(props: { children: InlineChildren }, { memo }: ComponentContext) {
   const flattened = [props.children].flat(Infinity as 1) as InlineChild[];
   return flattened.reduce((prefix: Node[], current) => {
     if (typeof current === 'function') {

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import pino from 'pino';
-import { Element } from '../index.js';
+import { Element } from './node.js';
 
 export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
 

--- a/packages/ai-jsx/src/core/memoize.tsx
+++ b/packages/ai-jsx/src/core/memoize.tsx
@@ -1,60 +1,28 @@
-import * as AI from '../index.js';
-import { RenderContext, Node, Renderable } from '../index.js';
+import { Renderable, RenderContext, AppendOnlyStream } from './render.js';
+import { Node, getReferencedNode, isIndirectNode, makeIndirectNode, isElement } from './node.js';
 import { Logger } from './log.js';
 
 let memoizedId = 0;
+/** @hidden */
 export const isMemoizedSymbol = Symbol('isMemoized');
 
 /**
- * Memoize a {@link Renderable} so it always returns the same thing.
- *
- * For example, imagine you have the following:
- * ```tsx
- *    const catName = (
- *      <ChatCompletion>
- *        <UserMessage>Give me a cat name</UserMessage>
- *      </ChatCompletion>
- *    );
- *
- *    <ChatCompletion>
- *      <UserMessage>
- *        I have a cat named {catName}. Tell me a story about {catName}.
- *      </UserMessage>
- *     </ChatCompletion>
- * ```
- *
- * In this case, `catName` will result in two separate model calls, so you'll get two different cat names.
- *
- * If this is not desired, you can wrap the component in `memo`:
- * ```tsx
- *    const catName = memo(<ChatCompletion>
- *      <UserMessage>Give me a cat name</UserMessage>
- *    </ChatCompletion>);
- *
- *    <ChatCompletion>
- *      <UserMessage>
- *        I have a cat named {catName}. Tell me a story about {catName}.
- *      </UserMessage>
- *     </ChatCompletion>
- * ```
- * Now, `catName` will result in a single model call, and its value will be reused everywhere that component appears
- * in the tree.
- *
- * The memoization is fully recursive.
+ * "Partially" memoizes a renderable such that it will only be rendered once in any
+ * single `RenderContext`.
  */
-export function memo(renderable: Renderable): Node {
+export function partialMemo(renderable: Renderable): Node {
   if (typeof renderable !== 'object' || renderable === null) {
     return renderable;
   }
-  if (AI.isIndirectNode(renderable)) {
-    const memoized = memo(AI.getReferencedNode(renderable));
-    return AI.makeIndirectNode(renderable, memoized);
+  if (isIndirectNode(renderable)) {
+    const memoized = partialMemo(getReferencedNode(renderable));
+    return makeIndirectNode(renderable, memoized);
   }
 
   if (Array.isArray(renderable)) {
-    return renderable.map(memo);
+    return renderable.map(partialMemo);
   }
-  if (AI.isElement(renderable)) {
+  if (isElement(renderable)) {
     if (isMemoizedSymbol in renderable.props) {
       return renderable;
     }
@@ -71,7 +39,7 @@ export function memo(renderable: Renderable): Node {
 
         let renderResult: Renderable;
         try {
-          renderResult = memo(renderable.render(ctx, logger));
+          renderResult = partialMemo(renderable.render(ctx, logger));
         } catch (ex) {
           // Wrap it in a promise so that it throws on await.
           renderResult = Promise.reject(ex);
@@ -94,14 +62,14 @@ export function memo(renderable: Renderable): Node {
     // It's an async iterable (which might be mutable). We set up some machinery to buffer the
     // results so that we can create memoized iterators as necessary.
     const generator = renderable[Symbol.asyncIterator]();
-    const sink: (Renderable | typeof AI.AppendOnlyStream)[] = [];
-    let finalResult: Renderable | typeof AI.AppendOnlyStream = null;
+    const sink: (Renderable | typeof AppendOnlyStream)[] = [];
+    let finalResult: Renderable | typeof AppendOnlyStream = null;
     let completed = false;
     let nextPromise: Promise<void> | null = null;
 
     const MemoizedGenerator = async function* (): AsyncGenerator<
-      Renderable | typeof AI.AppendOnlyStream,
-      Renderable | typeof AI.AppendOnlyStream
+      Renderable | typeof AppendOnlyStream,
+      Renderable | typeof AppendOnlyStream
     > {
       let index = 0;
       while (true) {
@@ -112,7 +80,7 @@ export function memo(renderable: Renderable): Node {
           return finalResult;
         } else if (nextPromise == null) {
           nextPromise = generator.next().then((result) => {
-            const memoized = result.value === AI.AppendOnlyStream ? result.value : memo(result.value);
+            const memoized = result.value === AppendOnlyStream ? result.value : partialMemo(result.value);
             if (result.done) {
               completed = true;
               finalResult = memoized;
@@ -130,7 +98,7 @@ export function memo(renderable: Renderable): Node {
     return <MemoizedGenerator id={++memoizedId} {...{ [isMemoizedSymbol]: true }} />;
   }
 
-  const memoizedRenderable = renderable.then(memo);
+  const memoizedRenderable = renderable.then(partialMemo);
   const MemoizedPromise = () => memoizedRenderable;
   return <MemoizedPromise id={++memoizedId} {...{ [isMemoizedSymbol]: true }} />;
 }

--- a/packages/ai-jsx/src/core/memoize.tsx
+++ b/packages/ai-jsx/src/core/memoize.tsx
@@ -7,6 +7,7 @@ let memoizedId = 0;
 export const isMemoizedSymbol = Symbol('isMemoized');
 
 /**
+ * @hidden
  * "Partially" memoizes a renderable such that it will only be rendered once in any
  * single `RenderContext`.
  */
@@ -27,8 +28,10 @@ export function partialMemo(renderable: Renderable): Node {
       return renderable;
     }
 
-    // N.B. The memoization applies per-RenderContext -- if the same component is rendered under
-    // two different RenderContexts, it won't be memoized.
+    // N.B. "Partial" memoization applies per-RenderContext -- if the same component is
+    // rendered under two different RenderContexts, it won't be memoized. However, the
+    // top-level RenderContext.memo will additionally bind the top-level `Renderable` to a
+    // single RenderContext to ensure that it only renders once.
     const memoizedValues = new WeakMap<RenderContext, Renderable>();
     const newElement = {
       ...renderable,

--- a/packages/ai-jsx/src/core/node.ts
+++ b/packages/ai-jsx/src/core/node.ts
@@ -80,13 +80,13 @@ export function withContext(renderable: Renderable, context: RenderContext): Ele
     return renderable;
   }
 
-  const withContext = {
+  const elementWithContext = {
     ...(isElement(renderable) ? renderable : createElement(SwitchContext, null)),
     [attachedContextSymbol]: context,
   };
 
-  Object.freeze(withContext);
-  return withContext;
+  Object.freeze(elementWithContext);
+  return elementWithContext;
 }
 
 /** @hidden */

--- a/packages/ai-jsx/src/core/node.ts
+++ b/packages/ai-jsx/src/core/node.ts
@@ -1,0 +1,137 @@
+/**
+ * This module defines the core node and element interfaces for AI.JSX.
+ *
+ * See: https://ai-jsx.com for more details.
+ *
+ * @packageDocumentation
+ */
+
+import { RenderContext, Renderable } from './render.js';
+import { Logger } from './log.js';
+
+/** A context that is used to render an AI.JSX component. */
+export interface ComponentContext extends RenderContext {
+  logger: Logger;
+}
+
+/** Represents a single AI.JSX component. */
+export type Component<P> = (props: P, context: ComponentContext) => Renderable;
+
+/**
+ * A Literal represents a literal value.
+ */
+export type Literal = string | number | null | undefined | boolean;
+
+const attachedContextSymbol = Symbol('AI.attachedContext');
+/**
+ * An Element represents an instance of an AI.JSX component, with an associated tag, properties, and a render function.
+ */
+export interface Element<P> {
+  /** The tag associated with this {@link Element}. */
+  tag: Component<P>;
+  /** The component properties. */
+  props: P;
+  /** A function that renders this {@link Element} to a {@link Renderable}. */
+  render: (renderContext: RenderContext, logger: Logger) => Renderable;
+  /** The {@link RenderContext} associated with this {@link Element}. */
+  [attachedContextSymbol]?: RenderContext;
+}
+
+const indirectNodeSymbol = Symbol('AI.indirectNode');
+/**
+ * An IndirectNode represents an opaque type with a reference to a {@link Node} that represents it.
+ */
+export interface IndirectNode {
+  [indirectNodeSymbol]: Node;
+}
+
+/**
+ * A Node represents an element of an AI.JSX component tree.
+ */
+export type Node = Element<any> | Literal | Node[] | IndirectNode;
+
+/** @hidden */
+export type ElementPredicate = (e: Element<any>) => boolean;
+
+/** @hidden */
+export type PropsOfComponent<T extends Component<any>> = T extends Component<infer P> ? P : never;
+
+/** @hidden */
+export function isIndirectNode(value: unknown): value is IndirectNode {
+  return value !== null && typeof value === 'object' && indirectNodeSymbol in value;
+}
+
+/** @hidden */
+export function getReferencedNode(value: IndirectNode): Node {
+  return value[indirectNodeSymbol];
+}
+
+/** @hidden */
+export function makeIndirectNode<T extends object>(value: T, node: Node): T & IndirectNode {
+  return new Proxy(value, {
+    has: (target, p) => p === indirectNodeSymbol || p in target,
+    get: (target, p, receiver) => (p === indirectNodeSymbol ? node : Reflect.get(target, p, receiver)),
+  }) as T & IndirectNode;
+}
+
+/** @hidden */
+export function withContext(renderable: Renderable, context: RenderContext): Element<any> {
+  function SwitchContext() {
+    return renderable;
+  }
+
+  const withContext = {
+    ...(isElement(renderable) ? renderable : createElement(SwitchContext, null)),
+    [attachedContextSymbol]: context,
+  };
+
+  Object.freeze(withContext);
+  return withContext;
+}
+
+/** @hidden */
+export function attachedContext(element: Element<any>): RenderContext | undefined {
+  return element[attachedContextSymbol];
+}
+
+export function createElement<P extends { children: C }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
+  ...children: [C]
+): Element<P>;
+/** @hidden */
+export function createElement<P extends { children: C[] }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
+  ...children: C[]
+): Element<P>;
+/** @hidden */
+export function createElement<P extends { children: C | C[] }, C>(
+  tag: Component<P>,
+  props: Omit<P, 'children'> | null,
+  ...children: C[]
+): Element<P> {
+  const propsToPass = {
+    ...(props ?? {}),
+    ...(children.length === 0 ? {} : { children: children.length === 1 ? children[0] : children }),
+  } as P;
+
+  const result = {
+    tag,
+    props: propsToPass,
+    render: (ctx, logger) => tag(propsToPass, { ...ctx, logger }),
+  } as Element<P>;
+  Object.freeze(propsToPass);
+  Object.freeze(result);
+  return result;
+}
+
+/** @hidden */
+export function isElement(value: unknown): value is Element<any> {
+  return value !== null && typeof value === 'object' && 'tag' in value;
+}
+
+/** @hidden */
+export function Fragment({ children }: { children: Node }): Renderable {
+  return children;
+}

--- a/packages/ai-jsx/src/index.ts
+++ b/packages/ai-jsx/src/index.ts
@@ -6,4 +6,5 @@
  * @packageDocumentation
  */
 
-export * from './core/core.js';
+export * from './core/node.js';
+export * from './core/render.js';

--- a/packages/ai-jsx/src/inspector/console.tsx
+++ b/packages/ai-jsx/src/inspector/console.tsx
@@ -3,7 +3,6 @@ import * as AI from '../index.js';
 import { Node } from '../index.js';
 import { useState, useEffect } from 'react';
 import SyntaxHighlight from './syntax-highlight.js';
-import { memo } from '../core/memoize.js';
 import Spinner from './spinner.js';
 import { DebugTree } from '../core/debug.js';
 
@@ -87,7 +86,7 @@ function Inspector({ componentToInspect, showDebugTree }: { componentToInspect: 
 
   useEffect(() => {
     const renderContext = AI.createRenderContext();
-    const memoized = memo(componentToInspect);
+    const memoized = renderContext.memo(componentToInspect);
 
     async function getAllFrames() {
       // This results in some duplicate pages.

--- a/packages/ai-jsx/tsconfig.json
+++ b/packages/ai-jsx/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "typedocOptions": {
     "entryPoints": [
-      "src/core/core.ts",
+      "src/index.ts",
       "src/core/completion.tsx",
       "src/core/debug.tsx",
       "src/core/error-boundary.ts",
@@ -14,7 +14,8 @@
       "src/core/image-gen.tsx",
       "src/core/inline.tsx",
       "src/core/log.ts",
-      "src/core/memoize.tsx",
+      "src/core/node.ts",
+      "src/core/render.ts",
       "src/inspector/console.tsx",
       "src/lib/openai.tsx",
       "src/batteries/constrained-output.tsx",

--- a/packages/create-react-app-demo/src/choose-your-adventure/ai.tsx
+++ b/packages/create-react-app-demo/src/choose-your-adventure/ai.tsx
@@ -4,7 +4,6 @@ import * as AI from 'ai-jsx/react';
 import { useEffect, useRef } from 'react';
 import { z } from 'zod';
 import { AssistantMessage, ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completion';
-import { memo } from 'ai-jsx/core/memoize';
 import { OpenAI } from 'ai-jsx/lib/openai';
 import { atom, useAtom } from 'jotai';
 import _ from 'lodash';
@@ -91,7 +90,6 @@ function AIComponent() {
   const [, setCallInProgress] = useAtom(modelCallInProgress);
   const isInProgressRef = useRef(false);
 
-  const children = memo(<ButtonEnabledAgent conversation={conversation} />);
   const when = !conversation.length || _.last(conversation)?.type === 'user';
 
   const lastMessageType = _.last(conversation)?.type;
@@ -105,7 +103,7 @@ function AIComponent() {
     // I couldn't get streaming to work here and I don't know why.
     // Maybe because we're in the client and however Axios is doing it only works in Node?
     AI.createRenderContext()
-      .render(children)
+      .render(<ButtonEnabledAgent conversation={conversation} />)
       .then((finalFrame) => {
         isInProgressRef.current = false;
         setCallInProgress(false);
@@ -145,7 +143,7 @@ function AIComponent() {
           console.log('Error normalizing JSON from model:', e, parts);
         }
       });
-  }, [children, lastMessageType, setCallInProgress, when, setConversation]);
+  }, [conversation, lastMessageType, setCallInProgress, when, setConversation]);
 
   return null;
 }

--- a/packages/create-react-app-demo/src/recipe/page.tsx
+++ b/packages/create-react-app-demo/src/recipe/page.tsx
@@ -3,7 +3,6 @@ import * as AI from 'ai-jsx/react';
 import { UICompletion } from 'ai-jsx/react/completion';
 import { useState, ReactNode } from 'react';
 import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
-import { memo } from 'ai-jsx/core/memoize';
 import { Prompt } from 'ai-jsx/batteries/prompts';
 import { ImageGen } from 'ai-jsx/core/image-gen';
 import ResultContainer from '../ResultContainer.tsx';
@@ -73,15 +72,51 @@ export function RecipeInstructionListItem({ children }: { children: ReactNode })
   return <li data-test="recipe-instruction-list-item">{children}</li>;
 }
 
-export default function RecipeWrapper() {
-  const [query, setQuery] = useState('braised lamb stew');
-
+function RecipeAI({ query }: { query: string }, { memo }: AI.ComponentContext) {
   const recipe = memo(
     <ChatCompletion temperature={1}>
       <Prompt persona="a Michelin Star Head Chef" />
       <UserMessage>Give me a recipe for {query}.</UserMessage>
     </ChatCompletion>
   );
+
+  return (
+    <>
+      <ImageGen size="256x256">
+        <ChatCompletion>
+          <UserMessage>
+            In two to three sentences, describe how the following recipe would look like when prepared by a chef:
+            {recipe}
+          </UserMessage>
+        </ChatCompletion>
+      </ImageGen>
+      <UICompletion
+        example={
+          <Recipe>
+            <RecipeTitle>Crème Chantilly</RecipeTitle>
+            <RecipeIngredientList>
+              <RecipeIngredientListItem>2 cups heavy cream</RecipeIngredientListItem>
+              <RecipeIngredientListItem>2 tablespoons granulated sugar</RecipeIngredientListItem>
+              <RecipeIngredientListItem>1 teaspoon vanilla extract</RecipeIngredientListItem>
+            </RecipeIngredientList>
+            <RecipeInstructionList>
+              <RecipeInstructionListItem>Combine the ingredients in a large mixing bowl.</RecipeInstructionListItem>
+              <RecipeInstructionListItem>
+                Beat the contents on high speed until soft peaks form.
+              </RecipeInstructionListItem>
+              <RecipeIngredientListItem>Keep chilled until serving.</RecipeIngredientListItem>
+            </RecipeInstructionList>
+          </Recipe>
+        }
+      >
+        {recipe}
+      </UICompletion>
+    </>
+  );
+}
+
+export default function RecipeWrapper() {
+  const [query, setQuery] = useState('braised lamb stew');
 
   return (
     <>
@@ -92,37 +127,9 @@ export default function RecipeWrapper() {
         <InputPrompt label="What would you like a recipe for?" value={query} setValue={setQuery} />
       </ResultContainer>
       <ResultContainer title={`AI comes up with a recipe for "${query}"`}>
-        <AI.jsx>
-          <ImageGen size="256x256">
-            <ChatCompletion>
-              <UserMessage>
-                In two to three sentences, describe how the following recipe would look like when prepared by a chef:
-                {recipe}
-              </UserMessage>
-            </ChatCompletion>
-          </ImageGen>
-          <UICompletion
-            example={
-              <Recipe>
-                <RecipeTitle>Crème Chantilly</RecipeTitle>
-                <RecipeIngredientList>
-                  <RecipeIngredientListItem>2 cups heavy cream</RecipeIngredientListItem>
-                  <RecipeIngredientListItem>2 tablespoons granulated sugar</RecipeIngredientListItem>
-                  <RecipeIngredientListItem>1 teaspoon vanilla extract</RecipeIngredientListItem>
-                </RecipeIngredientList>
-                <RecipeInstructionList>
-                  <RecipeInstructionListItem>Combine the ingredients in a large mixing bowl.</RecipeInstructionListItem>
-                  <RecipeInstructionListItem>
-                    Beat the contents on high speed until soft peaks form.
-                  </RecipeInstructionListItem>
-                  <RecipeIngredientListItem>Keep chilled until serving.</RecipeIngredientListItem>
-                </RecipeInstructionList>
-              </Recipe>
-            }
-          >
-            {recipe}
-          </UICompletion>
-        </AI.jsx>
+        <AI.JSX>
+          <RecipeAI query={query} />
+        </AI.JSX>
       </ResultContainer>
     </>
   );

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.6.1
+## 0.7.0
+
+- Move `memo` to `AI.RenderContext` to ensure that memoized components render once, even if placed under a different context provider.
+
+## [0.6.1](https://github.com/fixie-ai/ai-jsx/commit/625459d25d538019e42afe8ba952c89b363ff662)
 
 - Add `AIJSX_LOG` environment variable to control log level and output location.
 

--- a/packages/docs/docs/guides/performance.md
+++ b/packages/docs/docs/guides/performance.md
@@ -188,11 +188,9 @@ Use AI.JSX's built-in support for memoization instead.
 Instead, use [`memo`](/api/modules/core_memoize#memo):
 
 ```tsx
-import { memo } from 'ai-jsx/core/memoize';
-
-function StoryGenerator(props, { render }) {
+function StoryGenerator(props, { memo }) {
   // highlight-next-line
-  const heroName = await memo(<CharacterName role="hero" />);
+  const heroName = memo(<CharacterName role="hero" />);
   const villainName = <CharacterName role="villain" />;
 
   return (

--- a/packages/docs/docs/guides/rules-of-jsx.md
+++ b/packages/docs/docs/guides/rules-of-jsx.md
@@ -111,7 +111,7 @@ function* GenerateImage() {
 
 AI.JSX will interpret each `yield`ed value as a new value which should totally overwrite the previously-yielded values, so the caller would see a progression of increasingly high-quality images.
 
-However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/core_core.md#appendonlystream) symbol to indicate that `yield`ed results should be interpreted as deltas:
+However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/core_render.md#appendonlystream) symbol to indicate that `yield`ed results should be interpreted as deltas:
 
 ```tsx
 import * as AI from 'ai-jsx';
@@ -128,13 +128,13 @@ function* GenerateText() {
 
 ## Component API
 
-Components take props as the first argument and [`ComponentContext`](../api/interfaces/core_core.ComponentContext) as the second:
+Components take props as the first argument and [`ComponentContext`](../api/interfaces/core_render.ComponentContext) as the second:
 
 ```tsx
 function MyComponent(props, componentContext) {}
 ```
 
-`componentContext` contains a [`render`](../api/interfaces/core_core.ComponentContext#render) method, which you can use to [render other JSX components](./rendering.md#rendering-from-a-component).
+`componentContext` contains a [`render`](../api/interfaces/core_render.ComponentContext#render) method, which you can use to [render other JSX components](./rendering.md#rendering-from-a-component).
 
 ### Context
 
@@ -173,7 +173,7 @@ Each instance of `CharacterGenerator` will use the context value set by its near
 
 See also:
 
-- API ([`packages/ai-jsx/src/core/core.ts`](../api/modules/core_core))
+- API ([`packages/ai-jsx/src/index.ts`](../api/modules/))
 - Usage example ([`packages/examples/src/context.tsx`](https://github.com/fixie-ai/ai-jsx/blob/main/packages/examples/src/context.tsx))
 
 ## Handling Errors

--- a/packages/docs/docs/tutorial/part1-completion.md
+++ b/packages/docs/docs/tutorial/part1-completion.md
@@ -52,7 +52,7 @@ distinctions are used by OpenAI's API to differentiate between the fixed, system
 of the prompt and the variable, user aspect of the prompt.
 
 In order to actually get a result, we need to pass our application to a
-[`RenderContext`](../api/interfaces/core_core.RenderContext) and call `render()` on it. The `RenderContext` is responsible
+[`RenderContext`](../api/interfaces/core_render.RenderContext) and call `render()` on it. The `RenderContext` is responsible
 for managing the state of the application and progressively evaluating the state
 of the application as it is rendered. The `render()` method returns a `Promise`
 that evaluates to a string, which is the final result of rendering the JSX

--- a/packages/examples/src/getting-started/index.tsx
+++ b/packages/examples/src/getting-started/index.tsx
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import * as AI from 'ai-jsx';
 import { ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completion';
 import { ImageGen } from 'ai-jsx/core/image-gen';
 import { showInspector } from 'ai-jsx/core/inspector';
-import { memo } from 'ai-jsx/core/memoize';
 import { Node } from 'ai-jsx';
 
 function loadData() {
@@ -66,7 +66,7 @@ function WriteStory() {
 
 // Disable the linter because this getting started file has two examples in one, and this one isn't used right now.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function WriteStoryWithImage() {
+function WriteStoryWithImage(props: {}, { memo }: AI.ComponentContext) {
   const story = memo(<WriteStory />);
   return (
     <>

--- a/packages/examples/src/image-generation.tsx
+++ b/packages/examples/src/image-generation.tsx
@@ -2,9 +2,8 @@ import * as AI from 'ai-jsx';
 import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
 import { Prompt } from 'ai-jsx/batteries/prompts';
 import { ImageGen } from 'ai-jsx/core/image-gen';
-import { memo } from 'ai-jsx/core/memoize';
 
-function RecipeWithImage() {
+function RecipeWithImage(_: {}, { memo }: AI.ComponentContext) {
   const recipeTitle = memo(
     <ChatCompletion temperature={1}>
       <Prompt persona="a Michelin Star Head Chef" />

--- a/packages/examples/src/mdx.tsx
+++ b/packages/examples/src/mdx.tsx
@@ -9,7 +9,6 @@ import z from 'zod';
 import { OpenAI } from 'ai-jsx/lib/openai';
 import { PinoLogger } from 'ai-jsx/core/log';
 import { pino } from 'pino';
-import { memo } from 'ai-jsx/core/memoize';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 function Card({ header, footer, children }: { header?: string; footer?: string; children: string }) {
@@ -109,7 +108,7 @@ const usageExample = <>
     ]} />
 </>;
 
-function QuestionAndAnswer({ children }: { children: AI.Node }) {
+function QuestionAndAnswer({ children }: { children: AI.Node }, { memo }: AI.ComponentContext) {
   const question = memo(children);
   return (
     <>

--- a/packages/examples/src/stream-ui.tsx
+++ b/packages/examples/src/stream-ui.tsx
@@ -4,13 +4,12 @@
 
 /** @jsxImportSource ai-jsx/react */
 import * as AI from 'ai-jsx/experimental/next';
-import { memo } from 'ai-jsx/core/memoize';
 import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
 import { makeComponentMap } from 'ai-jsx/react/map';
 import { pino } from 'pino';
 import { PinoLogger } from 'ai-jsx/core/log';
 
-function App() {
+function App(_: {}, { memo }: AI.ComponentContext) {
   const chatCompletion = memo(
     <ChatCompletion temperature={1}>
       <UserMessage>List five dog names</UserMessage>

--- a/packages/nextjs-demo/src/app/recipe/api/route.tsx
+++ b/packages/nextjs-demo/src/app/recipe/api/route.tsx
@@ -4,7 +4,6 @@ import { NextRequest } from 'next/server';
 import { ChatCompletion, SystemMessage, UserMessage } from 'ai-jsx/core/completion';
 import { UICompletion } from 'ai-jsx/react/completion';
 import RecipeMap from '@/components/Recipe.map';
-import { memo } from 'ai-jsx/core/memoize';
 import { ImageGen } from 'ai-jsx/core/image-gen';
 const {
   Recipe,
@@ -20,33 +19,14 @@ import path from 'path';
 // Flip this flag to use a fixture response. This makes it easier to iterate on the UI.
 const useFixture = false;
 
-export async function POST(request: NextRequest) {
-  const { topic } = await request.json();
-
+function RecipeAI({ query }: { query: string }, { memo }: AI.ComponentContext) {
   const recipe = memo(
     <ChatCompletion temperature={1}>
       <SystemMessage>You are an expert chef.</SystemMessage>
-      <UserMessage>Give me a recipe for {topic}.</UserMessage>
+      <UserMessage>Give me a recipe for {query}.</UserMessage>
     </ChatCompletion>
   );
-
-  // This is an intentional constant flag.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (useFixture) {
-    const textEncoder = new TextEncoder();
-    const fakeStream = fs.readFileSync(path.join(process.cwd(), 'src', 'app', 'recipe', 'api', 'fixture.txt'), 'utf-8');
-    return new Response(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(textEncoder.encode(fakeStream));
-          controller.close();
-        },
-      })
-    );
-  }
-
-  return AI.toReactStream(
-    RecipeMap,
+  return (
     <>
       <ChatCompletion>
         <SystemMessage>
@@ -54,7 +34,7 @@ export async function POST(request: NextRequest) {
           a question. Do not give any specific details about the type of recipe you'll return, aside from mentioning the
           user's topic.
         </SystemMessage>
-        <UserMessage>I'd like a recipe about {topic}</UserMessage>
+        <UserMessage>I'd like a recipe about {query}</UserMessage>
       </ChatCompletion>
       <ImageGen size="256x256">
         <ChatCompletion>
@@ -84,4 +64,25 @@ export async function POST(request: NextRequest) {
       </UICompletion>
     </>
   );
+}
+
+export async function POST(request: NextRequest) {
+  const { topic } = await request.json();
+
+  // This is an intentional constant flag.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (useFixture) {
+    const textEncoder = new TextEncoder();
+    const fakeStream = fs.readFileSync(path.join(process.cwd(), 'src', 'app', 'recipe', 'api', 'fixture.txt'), 'utf-8');
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(textEncoder.encode(fakeStream));
+          controller.close();
+        },
+      })
+    );
+  }
+
+  return AI.toReactStream(RecipeMap, <RecipeAI query={topic} />);
 }

--- a/packages/nextjs-experimental/src/app/recipe/page.tsx
+++ b/packages/nextjs-experimental/src/app/recipe/page.tsx
@@ -3,7 +3,6 @@ import * as AI from 'ai-jsx/experimental/next';
 import React, { Suspense } from 'react';
 import { UICompletion } from 'ai-jsx/react/completion';
 import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
-import { memo } from 'ai-jsx/core/memoize';
 import { ImageGen } from 'ai-jsx/core/image-gen';
 import { Prompt } from 'ai-jsx/batteries/prompts';
 import ResultContainer from '@/components/ResultContainer';
@@ -67,10 +66,7 @@ export function RecipeInstructionListItem({ children }: { children: React.ReactN
   return <li data-test="recipe-instruction-list-item">{children}</li>;
 }
 
-export default function RecipeWrapper({ searchParams }: { searchParams: any }) {
-  const defaultValue = 'braised lamb stew';
-  const query = searchParams.q ?? defaultValue;
-
+function RecipeAI({ query }: { query: string }, { memo }: AI.ComponentContext) {
   const recipe = memo(
     <ChatCompletion temperature={1}>
       <Prompt persona="a Michelin Star Head Chef" />
@@ -80,44 +76,53 @@ export default function RecipeWrapper({ searchParams }: { searchParams: any }) {
 
   return (
     <>
+      <ImageGen size="256x256">
+        Generate an image for the following dish:
+        <ChatCompletion>
+          <UserMessage>
+            In two to three sentences, describe how the following recipe would look like when prepared by a chef:
+            {recipe}
+          </UserMessage>
+        </ChatCompletion>
+      </ImageGen>
+      <UICompletion
+        example={
+          <Recipe>
+            <RecipeTitle>Crème Chantilly</RecipeTitle>
+            <RecipeIngredientList>
+              <RecipeIngredientListItem>2 cups heavy cream</RecipeIngredientListItem>
+              <RecipeIngredientListItem>2 tablespoons granulated sugar</RecipeIngredientListItem>
+              <RecipeIngredientListItem>1 teaspoon vanilla extract</RecipeIngredientListItem>
+            </RecipeIngredientList>
+            <RecipeInstructionList>
+              <RecipeInstructionListItem>Combine the ingredients in a large mixing bowl.</RecipeInstructionListItem>
+              <RecipeInstructionListItem>
+                Beat the contents on high speed until soft peaks form.
+              </RecipeInstructionListItem>
+              <RecipeIngredientListItem>Keep chilled until serving.</RecipeIngredientListItem>
+            </RecipeInstructionList>
+          </Recipe>
+        }
+      >
+        {recipe}
+      </UICompletion>
+    </>
+  );
+}
+
+export default function RecipeWrapper({ searchParams }: { searchParams: any }) {
+  const defaultValue = 'braised lamb stew';
+  const query = searchParams.q ?? defaultValue;
+
+  return (
+    <>
       <InputPrompt label="What would you like a recipe for?" defaultValue={defaultValue} />
 
       <ResultContainer title={`AI comes up with a recipe for "${query}"`}>
         <Suspense fallback={'Loading...'}>
-          <AI.jsx>
-            <ImageGen size="256x256">
-              Generate an image for the following dish:
-              <ChatCompletion>
-                <UserMessage>
-                  In two to three sentences, describe how the following recipe would look like when prepared by a chef:
-                  {recipe}
-                </UserMessage>
-              </ChatCompletion>
-            </ImageGen>
-            <UICompletion
-              example={
-                <Recipe>
-                  <RecipeTitle>Crème Chantilly</RecipeTitle>
-                  <RecipeIngredientList>
-                    <RecipeIngredientListItem>2 cups heavy cream</RecipeIngredientListItem>
-                    <RecipeIngredientListItem>2 tablespoons granulated sugar</RecipeIngredientListItem>
-                    <RecipeIngredientListItem>1 teaspoon vanilla extract</RecipeIngredientListItem>
-                  </RecipeIngredientList>
-                  <RecipeInstructionList>
-                    <RecipeInstructionListItem>
-                      Combine the ingredients in a large mixing bowl.
-                    </RecipeInstructionListItem>
-                    <RecipeInstructionListItem>
-                      Beat the contents on high speed until soft peaks form.
-                    </RecipeInstructionListItem>
-                    <RecipeIngredientListItem>Keep chilled until serving.</RecipeIngredientListItem>
-                  </RecipeInstructionList>
-                </Recipe>
-              }
-            >
-              {recipe}
-            </UICompletion>
-          </AI.jsx>
+          <AI.JSX>
+            <RecipeAI query={query} />
+          </AI.JSX>
         </Suspense>
       </ResultContainer>
     </>


### PR DESCRIPTION
This moves the `memo` function to `RenderContext`, where it will bind a `Renderable` to a single `RenderContext`. This ensures that it will only be rendered once and has symmetry with `render`.

This is a breaking change and bumps the version to `0.7.0`.

(To resolve circular import issues, it also splits `core.ts` into `node.ts` and `render.ts`.)