### PR TITLE
Change ChatCompletion to emit AssistantMessage

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -338,9 +338,9 @@ export async function* JsonChatCompletionFunctionCall(
 
   const frames = render(childrenWithCompletion, { stop: (e) => e.tag === FunctionCall, map: (e) => e });
   for await (const frame of frames) {
-    const functionCall = frame.find((e) => AI.isElement(e) && e.tag === FunctionCall) as AI.Element<
-      AI.PropsOfComponent<typeof FunctionCall>
-    >;
+    const functionCall = frame.find((e) => AI.isElement(e) && e.tag === FunctionCall) as
+      | AI.Element<AI.PropsOfComponent<typeof FunctionCall>>
+      | undefined;
     if (!functionCall) {
       continue;
     }
@@ -356,11 +356,15 @@ export async function* JsonChatCompletionFunctionCall(
     yield JSON.stringify(object);
   }
 
-  const functionCall = (await frames).find((e) => AI.isElement(e) && e.tag === FunctionCall) as AI.Element<
-    AI.PropsOfComponent<typeof FunctionCall>
-  >;
+  const functionCall = (await frames).find((e) => AI.isElement(e) && e.tag === FunctionCall) as
+    | AI.Element<AI.PropsOfComponent<typeof FunctionCall>>
+    | undefined;
 
-  const object = functionCall?.props.args;
+  if (functionCall === undefined) {
+    return null;
+  }
+
+  const object = functionCall.props.args;
   try {
     for (const validator of validatorsAndSchema) {
       validator(object);

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -11,6 +11,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
   AssistantMessage,
   ChatCompletion,
+  FunctionCall,
   ModelPropsWithChildren,
   SystemMessage,
   UserMessage,
@@ -318,7 +319,6 @@ export async function* JsonChatCompletionFunctionCall(
 
   const childrenWithCompletion = (
     <ChatCompletion
-      experimental_streamFunctionCallOnly
       {...props}
       functionDefinitions={{
         print: {
@@ -336,9 +336,16 @@ export async function* JsonChatCompletionFunctionCall(
     </ChatCompletion>
   );
 
-  const frames = render(childrenWithCompletion);
+  const frames = render(childrenWithCompletion, { stop: (e) => e.tag === FunctionCall, map: (e) => e });
   for await (const frame of frames) {
-    const object = JSON.parse(frame).arguments;
+    const functionCall = frame.find((e) => AI.isElement(e) && e.tag === FunctionCall) as AI.Element<
+      AI.PropsOfComponent<typeof FunctionCall>
+    >;
+    if (!functionCall) {
+      continue;
+    }
+
+    const object = functionCall.props.args;
     try {
       for (const validator of validatorsAndSchema) {
         validator(object);
@@ -348,7 +355,12 @@ export async function* JsonChatCompletionFunctionCall(
     }
     yield JSON.stringify(object);
   }
-  const object = JSON.parse(await frames).arguments;
+
+  const functionCall = (await frames).find((e) => AI.isElement(e) && e.tag === FunctionCall) as AI.Element<
+    AI.PropsOfComponent<typeof FunctionCall>
+  >;
+
+  const object = functionCall?.props.args;
   try {
     for (const validator of validatorsAndSchema) {
       validator(object);

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -345,15 +345,15 @@ export async function* JsonChatCompletionFunctionCall(
       continue;
     }
 
-    const object = functionCall.props.args;
+    const jsonResult = functionCall.props.args;
     try {
       for (const validator of validatorsAndSchema) {
-        validator(object);
+        validator(jsonResult);
       }
     } catch (e: any) {
       continue;
     }
-    yield JSON.stringify(object);
+    yield JSON.stringify(jsonResult);
   }
 
   const functionCall = (await frames).find((e) => AI.isElement(e) && e.tag === FunctionCall) as
@@ -364,16 +364,16 @@ export async function* JsonChatCompletionFunctionCall(
     return null;
   }
 
-  const object = functionCall.props.args;
+  const jsonResult = functionCall.props.args;
   try {
     for (const validator of validatorsAndSchema) {
-      validator(object);
+      validator(jsonResult);
     }
   } catch (e: any) {
     throw new CompletionError('The model did not produce a valid JSON object', 'runtime', {
-      output: JSON.stringify(object),
+      output: JSON.stringify(jsonResult),
       validationError: e.message,
     });
   }
-  return JSON.stringify(object);
+  return JSON.stringify(jsonResult);
 }

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -221,7 +221,7 @@ export async function* UseTools(props: UseToolsProps, { render }: RenderContext)
 /** @hidden */
 export async function* UseToolsFunctionCall(
   props: UseToolsProps,
-  { render, memo }: ComponentContext
+  { render, memo, logger }: ComponentContext
 ): RenderableStream {
   yield AppendOnlyStream;
 
@@ -253,6 +253,11 @@ export async function* UseToolsFunctionCall(
           }
           functionCallElement = element;
         }
+      } else {
+        logger.debug(
+          { text: element },
+          '<ChatCompletion> emitted something other than <AssistantMessage> or <FunctionCall>, which is unexpected.'
+        );
       }
     }
 

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -299,8 +299,16 @@ export function ConversationHistory({ messages }: { messages: ChatCompletionResp
  *    ==> "That would be 83,076."
  * ```
  */
-export function FunctionCall({ name, args }: { name: string; args: Record<string, string | number | boolean | null> }) {
-  return `Call function ${name} with ${JSON.stringify(args)}`;
+export function FunctionCall({
+  name,
+  partial,
+  args,
+}: {
+  name: string;
+  partial?: boolean;
+  args: Record<string, string | number | boolean | null>;
+}) {
+  return `Call function ${name} with ${partial ? '(incomplete) ' : ''}${JSON.stringify(args)}`;
 }
 
 /**

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -467,10 +467,11 @@ export async function* OpenAIChatModel(
       );
       yield <AssistantMessage>{assistantStream}</AssistantMessage>;
 
-      // Ensure the assistantStream() is flushed by rendering it.
+      // Ensure the assistantStream is flushed by rendering it.
       await render(assistantStream);
     }
 
+    // TS doesn't realize that the assistantStream closure can make `delta` be `null`.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (delta?.function_call) {
       // Memoize the stream to ensure it renders only once.
@@ -501,10 +502,11 @@ export async function* OpenAIChatModel(
       );
       yield functionCallStream;
 
-      // Ensure the functionStream() is flushed by rendering it.
+      // Ensure the functionCallStream is flushed by rendering it.
       await render(functionCallStream);
     }
 
+    // TS doesn't realize that the functionCallStream closure can make `delta` be `null`.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (delta !== null) {
       delta = await advance();

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -296,21 +296,13 @@ export async function* OpenAIChatModel(
       {
         functionDefinitions: Record<string, FunctionDefinition>;
         forcedFunction: string;
-
-        /**
-         * Internal only.
-         *
-         * If this flag is passed, this component will stream only the model Function Call. This is useful if the only thing you want is the function call, such as if you're using the function call to force the model to output JSON matching a schema.
-         */
-        experimental_streamFunctionCallOnly: boolean;
       },
       {
         functionDefinitions?: never;
         forcedFunction?: never;
-        experimental_streamFunctionCallOnly?: never;
       }
     >,
-  { render, getContext, logger }: AI.ComponentContext
+  { render, getContext, logger, memo }: AI.ComponentContext
 ): AI.RenderableStream {
   if (props.functionDefinitions) {
     if (!chatModelSupportsFunctions(props.model)) {
@@ -321,14 +313,6 @@ export async function* OpenAIChatModel(
       );
     }
   }
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  else if (props.experimental_streamFunctionCallOnly) {
-    throw new AIJSXError(
-      'The experimental_streamFunctionCallOnly flag can only be passed when function definitions are also passed.',
-      ErrorCode.ChatCompletionBadInput,
-      'user'
-    );
-  }
 
   if (props.forcedFunction && !Object.keys(props.functionDefinitions).includes(props.forcedFunction)) {
     throw new AIJSXError(
@@ -338,6 +322,8 @@ export async function* OpenAIChatModel(
     );
   }
 
+  yield AI.AppendOnlyStream;
+
   const messageElements = await render(props.children, {
     stop: (e) =>
       e.tag == SystemMessage ||
@@ -346,9 +332,7 @@ export async function* OpenAIChatModel(
       e.tag == FunctionCall ||
       e.tag == FunctionResponse,
   });
-  if (!props.experimental_streamFunctionCallOnly) {
-    yield AI.AppendOnlyStream;
-  }
+
   const messages: ChatCompletionRequestMessage[] = await Promise.all(
     messageElements.filter(AI.isElement).map(async (message) => {
       switch (message.tag) {
@@ -438,59 +422,97 @@ export async function* OpenAIChatModel(
     }
   >;
 
-  const currentMessage = { content: undefined, function_call: undefined } as Partial<ChatCompletionResponseMessage>;
-  let finishReason: string | undefined = undefined;
-  for await (const deltaMessage of openAiEventsToJson<ChatCompletionDelta>(
-    asyncIteratorOfFetchStream(chatResponse.body!.getReader())
-  )) {
-    logger.trace({ deltaMessage }, 'Got delta message');
-    finishReason = finishReason ?? deltaMessage.choices[0].finish_reason;
-    const delta = deltaMessage.choices[0].delta;
-    if (delta.role) {
-      currentMessage.role = deltaMessage.choices[0].delta.role;
+  const iterator = openAiEventsToJson<ChatCompletionDelta>(asyncIteratorOfFetchStream(chatResponse.body!.getReader()))[
+    Symbol.asyncIterator
+  ]();
+
+  // We have a single response iterator, but we'll wrap tokens _within_ the structure of <AssistantMessage> or <FunctionCall>
+  // components. This:
+  //  - Allows our stream to be append-only and therefore eagerly rendered in append-only contexts.
+  //  - Preserves the output structure to allow callers to extract/separate <AssistantMessage> and <FunctionCall> messages.
+  //  - Allows the intermediate states of the stream to include "partial" <FunctionCall> elements with healed JSON.
+  //
+  // This requires some gymnastics because several components will share a single iterator that can only be consumed once.
+  // That is, the logical loop execution is spread over multiple functions (closures over the shared iterator).
+  async function advance(): Promise<Partial<ChatCompletionResponseMessage> | null> {
+    const next = await iterator.next();
+    if (next.done) {
+      return null;
     }
-    if (delta.content) {
-      currentMessage.content = currentMessage.content ?? '';
-      currentMessage.content += delta.content;
-      if (!props.experimental_streamFunctionCallOnly) {
-        yield delta.content;
-      }
+
+    logger.trace({ deltaMessage: next.value }, 'Got delta message');
+    return next.value.choices[0].delta;
+  }
+
+  let delta = await advance();
+  while (delta !== null) {
+    if (delta.role === 'assistant') {
+      // Memoize the stream to ensure it renders only once.
+      const assistantStream = memo(
+        (async function* (): AI.RenderableStream {
+          yield AI.AppendOnlyStream;
+
+          while (delta !== null) {
+            if (delta.content) {
+              yield delta.content;
+            }
+            if (delta.function_call) {
+              break;
+            }
+            delta = await advance();
+          }
+
+          return AI.AppendOnlyStream;
+        })()
+      );
+      yield <AssistantMessage>{assistantStream}</AssistantMessage>;
+
+      // Ensure the assistantStream() is flushed by rendering it.
+      await render(assistantStream);
     }
-    if (delta.function_call) {
-      currentMessage.function_call = currentMessage.function_call ?? { name: '', arguments: '' };
-      if (delta.function_call.name) {
-        currentMessage.function_call.name += delta.function_call.name;
-      }
-      if (delta.function_call.arguments) {
-        currentMessage.function_call.arguments += delta.function_call.arguments;
-      }
-      if (props.experimental_streamFunctionCallOnly) {
-        yield JSON.stringify({
-          ...currentMessage.function_call,
-          // We actually want the argument to be '{}' if it's empty, not '""'.
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          arguments: JSON.parse(patchedUntruncateJson(currentMessage.function_call.arguments || '{}')),
-        });
-      }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (delta?.function_call) {
+      // Memoize the stream to ensure it renders only once.
+      const functionCallStream = memo(
+        (async function* () {
+          let name = '';
+          let argsJson = '';
+          while (delta != null) {
+            if (!delta.function_call) {
+              break;
+            }
+
+            if (delta.function_call.name) {
+              name += delta.function_call.name;
+            }
+
+            if (delta.function_call.arguments) {
+              argsJson += delta.function_call.arguments;
+            }
+
+            yield <FunctionCall partial name={name} args={JSON.parse(patchedUntruncateJson(argsJson || '{}'))} />;
+
+            delta = await advance();
+          }
+
+          return <FunctionCall name={name} args={JSON.parse(argsJson || '{}')} />;
+        })()
+      );
+      yield functionCallStream;
+
+      // Ensure the functionStream() is flushed by rendering it.
+      await render(functionCallStream);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (delta !== null) {
+      delta = await advance();
     }
   }
 
-  logger.debug({ message: currentMessage }, 'Finished createChatCompletion');
+  logger.debug('Finished createChatCompletion');
 
-  if (props.experimental_streamFunctionCallOnly) {
-    return JSON.stringify({
-      ...currentMessage.function_call,
-      arguments: JSON.parse(currentMessage.function_call?.arguments ?? '{}'),
-    });
-  }
-  if (currentMessage.function_call) {
-    yield (
-      <FunctionCall
-        name={currentMessage.function_call.name ?? ''}
-        args={JSON.parse(currentMessage.function_call.arguments ?? '{}')}
-      />
-    );
-  }
   return AI.AppendOnlyStream;
 }
 

--- a/packages/ai-jsx/src/lib/replicate-llama2.tsx
+++ b/packages/ai-jsx/src/lib/replicate-llama2.tsx
@@ -16,7 +16,7 @@ import { getEnvVar } from './util.js';
 /**
  * Run a Llama2 model on Replicate.
  */
-async function* fetchLlama2<ModelArgs extends Llama2ModelArgs>(
+async function fetchLlama2<ModelArgs extends Llama2ModelArgs>(
   modelId: Parameters<Replicate['run']>[0],
   input: ModelArgs,
   logger: AI.ComponentContext['logger']
@@ -30,7 +30,6 @@ async function* fetchLlama2<ModelArgs extends Llama2ModelArgs>(
   const output = (await replicate.run(modelId, { input })) as string[];
   const result = output.join('');
   logger.debug({ result }, 'Replicate llama2 output');
-  yield result;
   return result;
 }
 
@@ -143,12 +142,15 @@ export async function* Llama2ChatModel(
     prompt: await render(userMessages[0]),
     system_prompt: systemMessage.length ? await render(systemMessage[0]) : undefined,
   };
-  const response = await fetchLlama2(
-    'replicate/llama70b-v2-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48',
-    llama2Args,
-    logger
+  yield (
+    <AssistantMessage>
+      {await fetchLlama2(
+        'replicate/llama70b-v2-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48',
+        llama2Args,
+        logger
+      )}
+    </AssistantMessage>
   );
-  yield* response;
   return AI.AppendOnlyStream;
 }
 
@@ -175,7 +177,7 @@ export async function* Llama2CompletionModel(
     llama2Args,
     logger
   );
-  yield* response;
+  yield response;
   return AI.AppendOnlyStream;
 }
 

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.7.0
+## 0.7.1
+
+- Change `ChatCompletion` components to render to `<AssistantMessage>` and `<FunctionCall>` elements.
+
+## [0.7.0](https://github.com/fixie-ai/ai-jsx/commit/f8c8cff92fa1f228bf5826e8a0ac7129df765150)
 
 - Move `memo` to `AI.RenderContext` to ensure that memoized components render once, even if placed under a different context provider.
 


### PR DESCRIPTION
This changes the various `ChatCompletion` implementations to emit `<AssistantMessage>`s rather than loose text. This allows callers to easily separate `<AssistantMessage>` and `<FunctionCall>` outputs.

Preserving the append-only nature of the stream requires non-trivial gymnastics to split the iterator consumption across multiple components, but this technique also allows for the removal of the `experimental_streamFunctionCallOnly` flag.