### PR TITLE
Add `Converse` and `ShowConversation` components

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "volta": {
     "extends": "../../package.json"
   },
@@ -79,6 +79,15 @@
       },
       "require": {
         "default": "./dist/cjs/core/completion.cjs"
+      }
+    },
+    "./core/conversation": {
+      "import": {
+        "types": "./dist/esm/core/conversation.d.ts",
+        "default": "./dist/esm/core/conversation.js"
+      },
+      "require": {
+        "default": "./dist/cjs/core/conversation.cjs"
       }
     },
     "./core/image-gen": {

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -3,7 +3,6 @@
  * @packageDocumentation
  */
 
-import { ChatCompletionResponseMessage } from 'openai';
 import * as AI from '../index.js';
 import { Node, Component, RenderContext } from '../index.js';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
@@ -12,6 +11,14 @@ import { getEnvVar } from '../lib/util.js';
 import { AnthropicChatModel } from '../lib/anthropic.js';
 import z from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+export {
+  UserMessage,
+  SystemMessage,
+  AssistantMessage,
+  FunctionCall,
+  FunctionResponse,
+  ConversationHistory,
+} from './conversation.js';
 
 /**
  * Represents properties passed to a given Large Language Model.
@@ -209,130 +216,6 @@ export function ChatProvider<T extends ModelPropsWithChildren>(
       {children}
     </chatContext.Provider>
   );
-}
-
-/**
- * Provide a System Message to the LLM, for use within a {@link ChatCompletion}.
- *
- * The system message can be used to put the model in character. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
- *
- * @example
- * ```tsx
- *    <ChatCompletion>
- *      <SystemMessage>You are a helpful customer service agent.</SystemMessage>
- *    </ChatCompletion>
- * ```
- */
-export function SystemMessage({ children }: { children: Node }) {
-  return children;
-}
-
-/**
- * Provide a User Message to the LLM, for use within a {@link ChatCompletion}.
- *
- * The user message tells the model what the user has said. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
- *
- * @example
- * ```tsx
- *    <ChatCompletion>
- *      <UserMessage>I'd like to cancel my account.</UserMessage>
- *    </ChatCompletion>
- *
- *    ==> 'Sorry to hear that. Can you tell me why?
- * ```
- */
-export function UserMessage({ children }: { name?: string; children: Node }) {
-  return children;
-}
-
-/**
- * Provide an Assistant Message to the LLM, for use within a {@link ChatCompletion}.
- *
- * The assistant message tells the model what it has previously said. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
- *
- * @example
- * ```tsx
- *    <ChatCompletion>
- *      <UserMessage>I'd like to cancel my account.</UserMessage>
- *      <AssistantMessage>Sorry to hear that. Can you tell me why?</AssistantMessage>
- *      <UserMessage>It's too expensive.</UserMessage>
- *    </ChatCompletion>
- * ```
- *
- *    ==> "Ok, thanks for that feedback. I'll cancel your account."
- */
-export function AssistantMessage({ children }: { children: Node }) {
-  return children;
-}
-
-export function ConversationHistory({ messages }: { messages: ChatCompletionResponseMessage[] }) {
-  return messages.map((message) => {
-    switch (message.role) {
-      case 'system':
-        return <SystemMessage>{message.content}</SystemMessage>;
-      case 'user':
-        return <UserMessage>{message.content}</UserMessage>;
-      case 'assistant':
-        return <AssistantMessage>{message.content}</AssistantMessage>;
-      case 'function':
-        return (
-          <FunctionCall name={message.function_call!.name!} args={JSON.parse(message.function_call!.arguments!)} />
-        );
-    }
-  });
-}
-
-/**
- * Provide a function call to the LLM, for use within a {@link ChatCompletion}.
- *
- * The function call tells the model that a function was previously invoked by the model. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
- * When the model returns a function call, @{link ChatCompletion} returns a @{link FunctionCall} component.
- *
- * @example
- * ```tsx
- *    <ChatCompletion>
- *      <UserMessage>What is 258 * 322?</UserMessage>
- *      <FunctionCall name="evaluate_math" args={expression: "258 * 322"} />
- *      <FunctionResponse name="evaluate_math">83076</FunctionResponse>
- *    </ChatCompletion>
- *
- *    ==> "That would be 83,076."
- * ```
- */
-export function FunctionCall({
-  name,
-  partial,
-  args,
-}: {
-  name: string;
-  partial?: boolean;
-  args: Record<string, string | number | boolean | null>;
-}) {
-  return `Call function ${name} with ${partial ? '(incomplete) ' : ''}${JSON.stringify(args)}`;
-}
-
-/**
- * Renders to the output of a previous {@link FunctionCall} component, for use within a {@link ChatCompletion}.
- *
- * See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
- *
- * @example
- * ```tsx
- *    <ChatCompletion>
- *      <UserMessage>What is 258 * 322?</UserMessage>
- *      <FunctionCall name="evaluate_math" args={expression: "258 * 322"} />
- *      <FunctionResponse name="evaluate_math">83076</FunctionResponse>
- *    </ChatCompletion>
- *
- *    ==> "That would be 83,076."
- * ```
- */
-export async function FunctionResponse(
-  { name, children }: { name: string; children: Node },
-  { render }: AI.ComponentContext
-) {
-  const output = await render(children);
-  return `function ${name} returns ${output}`;
 }
 
 /**

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -1,0 +1,295 @@
+import { ChatCompletionResponseMessage } from 'openai';
+import * as AI from '../index.js';
+import { Node } from '../index.js';
+import { AIJSXError, ErrorCode } from '../core/errors.js';
+
+/**
+ * Provide a System Message to the LLM, for use within a {@link ChatCompletion}.
+ *
+ * The system message can be used to put the model in character. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
+ *
+ * @example
+ * ```tsx
+ *    <ChatCompletion>
+ *      <SystemMessage>You are a helpful customer service agent.</SystemMessage>
+ *    </ChatCompletion>
+ * ```
+ */
+export function SystemMessage({ children }: { children: Node }) {
+  return children;
+}
+
+/**
+ * Provide a User Message to the LLM, for use within a {@link ChatCompletion}.
+ *
+ * The user message tells the model what the user has said. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
+ *
+ * @example
+ * ```tsx
+ *    <ChatCompletion>
+ *      <UserMessage>I'd like to cancel my account.</UserMessage>
+ *    </ChatCompletion>
+ *
+ *    ==> 'Sorry to hear that. Can you tell me why?
+ * ```
+ */
+export function UserMessage({ children }: { name?: string; children: Node }) {
+  return children;
+}
+
+/**
+ * Provide an Assistant Message to the LLM, for use within a {@link ChatCompletion}.
+ *
+ * The assistant message tells the model what it has previously said. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
+ *
+ * @example
+ * ```tsx
+ *    <ChatCompletion>
+ *      <UserMessage>I'd like to cancel my account.</UserMessage>
+ *      <AssistantMessage>Sorry to hear that. Can you tell me why?</AssistantMessage>
+ *      <UserMessage>It's too expensive.</UserMessage>
+ *    </ChatCompletion>
+ * ```
+ *
+ *    ==> "Ok, thanks for that feedback. I'll cancel your account."
+ */
+export function AssistantMessage({ children }: { children: Node }) {
+  return children;
+}
+
+export function ConversationHistory({ messages }: { messages: ChatCompletionResponseMessage[] }) {
+  return messages.map((message) => {
+    switch (message.role) {
+      case 'system':
+        return <SystemMessage>{message.content}</SystemMessage>;
+      case 'user':
+        return <UserMessage>{message.content}</UserMessage>;
+      case 'assistant':
+        return <AssistantMessage>{message.content}</AssistantMessage>;
+      case 'function':
+        return (
+          <FunctionCall name={message.function_call!.name!} args={JSON.parse(message.function_call!.arguments!)} />
+        );
+    }
+  });
+}
+
+/**
+ * Provide a function call to the LLM, for use within a {@link ChatCompletion}.
+ *
+ * The function call tells the model that a function was previously invoked by the model. See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
+ * When the model returns a function call, @{link ChatCompletion} returns a @{link FunctionCall} component.
+ *
+ * @example
+ * ```tsx
+ *    <ChatCompletion>
+ *      <UserMessage>What is 258 * 322?</UserMessage>
+ *      <FunctionCall name="evaluate_math" args={expression: "258 * 322"} />
+ *      <FunctionResponse name="evaluate_math">83076</FunctionResponse>
+ *    </ChatCompletion>
+ *
+ *    ==> "That would be 83,076."
+ * ```
+ */
+export function FunctionCall({
+  name,
+  partial,
+  args,
+}: {
+  name: string;
+  partial?: boolean;
+  args: Record<string, string | number | boolean | null>;
+}) {
+  return `Call function ${name} with ${partial ? '(incomplete) ' : ''}${JSON.stringify(args)}`;
+}
+
+/**
+ * Renders to the output of a previous {@link FunctionCall} component, for use within a {@link ChatCompletion}.
+ *
+ * See https://platform.openai.com/docs/guides/gpt/chat-completions-api for more detail.
+ *
+ * @example
+ * ```tsx
+ *    <ChatCompletion>
+ *      <UserMessage>What is 258 * 322?</UserMessage>
+ *      <FunctionCall name="evaluate_math" args={expression: "258 * 322"} />
+ *      <FunctionResponse name="evaluate_math">83076</FunctionResponse>
+ *    </ChatCompletion>
+ *
+ *    ==> "That would be 83,076."
+ * ```
+ */
+export async function FunctionResponse(
+  { name, children }: { name: string; children: Node },
+  { render }: AI.ComponentContext
+) {
+  const output = await render(children);
+  return `function ${name} returns ${output}`;
+}
+
+interface ConversationMessageType<T, C extends AI.Component<any>> {
+  type: T;
+  element: AI.Element<AI.PropsOfComponent<C>>;
+}
+
+/**
+ * A type that represents a conversation message.
+ */
+export type ConversationMessage =
+  | ConversationMessageType<'user', typeof UserMessage>
+  | ConversationMessageType<'assistant', typeof AssistantMessage>
+  | ConversationMessageType<'system', typeof SystemMessage>
+  | ConversationMessageType<'functionCall', typeof FunctionCall>
+  | ConversationMessageType<'functionResponse', typeof FunctionResponse>;
+
+/** @hidden */
+export function isConversationalComponent(element: AI.Element<any>): boolean {
+  return (
+    element.tag === UserMessage ||
+    element.tag === AssistantMessage ||
+    element.tag === SystemMessage ||
+    element.tag === FunctionCall ||
+    element.tag === FunctionResponse
+  );
+}
+
+function toConversationMessages(partialRendering: AI.PartiallyRendered[]): ConversationMessage[] {
+  return partialRendering
+    .flatMap((e) => (AI.isElement(e) ? [e] : []))
+    .map<ConversationMessage>((e) => {
+      switch (e.tag) {
+        case UserMessage:
+          return { type: 'user', element: e };
+        case AssistantMessage:
+          return { type: 'assistant', element: e };
+        case SystemMessage:
+          return { type: 'system', element: e };
+        case FunctionCall:
+          return { type: 'functionCall', element: e };
+        case FunctionResponse:
+          return { type: 'functionResponse', element: e };
+        default:
+          throw new AIJSXError(
+            `Unexpected tag (${e.tag.name}) in conversation`,
+            ErrorCode.UnexpectedPartialRenderResult,
+            'internal'
+          );
+      }
+    });
+}
+
+/** @hidden */
+export async function renderToConversation(
+  conversation: AI.Node,
+  render: AI.ComponentContext['render']
+): Promise<ConversationMessage[]> {
+  return toConversationMessages(await render(conversation, { stop: isConversationalComponent }));
+}
+
+/**
+ * A component that appends messages to a conversation according to a `reply` function.
+ *
+ * The `reply` function is invoked with the new messages produced from its _own replies_ until
+ * it fails to return a conversational message (e.g. UserMessage or AssistantMessage). The first
+ * invocation includes the messages from the `children` prop.
+ *
+ * @example
+ * ```tsx
+ *    <Converse reply={(messages) => messages[0].type === "user" ? <AssistantMessage>Hello there!</AssistantMessage> : null}>
+ *      <UserMessage>Hello!</UserMessage>
+ *    </ChatCompletion>
+ *
+ *    ==> 'Hello there!'
+ * ```
+ *
+ */
+export async function* Converse(
+  {
+    reply,
+    children,
+  }: {
+    reply: (messages: ConversationMessage[], fullConversation: ConversationMessage[]) => AI.Renderable;
+    children: AI.Node;
+  },
+  { render, memo }: AI.ComponentContext
+): AI.RenderableStream {
+  yield AI.AppendOnlyStream;
+
+  let fullConversation = [] as ConversationMessage[];
+  let next = memo(children);
+  while (true) {
+    const messages = await renderToConversation(next, render);
+    if (messages.length === 0) {
+      break;
+    }
+
+    fullConversation = fullConversation.concat(messages);
+    next = memo(reply(messages, fullConversation));
+    yield next;
+  }
+
+  return AI.AppendOnlyStream;
+}
+
+/**
+ * Allows the presentation of conversational components ({@link UserMessage} et al) to be altered.
+ *
+ * Also accepts an `onComplete` prop, which will be invoked once per render with the entire conversation.
+ *
+ * @example
+ * ```tsx
+ *     <ShowConversation present={(msg) => msg.type === "assistant" && <>Assistant: {msg.element}</>}>
+ *         <UserMessage>This is not visible.</UserMessage>
+ *         <Assistant>This is visible!</UserMessage>
+ *     </ShowConversation>
+ *
+ *     ==> 'Assistant: This is visible!'
+ * ```
+ */
+export async function* ShowConversation(
+  {
+    children: children,
+    present,
+    onComplete,
+  }: {
+    children: AI.Node;
+    present?: (message: ConversationMessage) => AI.Node;
+    onComplete?: (conversation: ConversationMessage[], render: AI.RenderContext['render']) => Promise<void> | void;
+  },
+  { render, isAppendOnlyRender, memo }: AI.ComponentContext
+): AI.RenderableStream {
+  // If we're in an append-only render, do the transformation in an append-only manner so as not to block.
+  if (isAppendOnlyRender) {
+    yield AI.AppendOnlyStream;
+  }
+
+  let lastFrame = [] as AI.PartiallyRendered[];
+  let conversationMessages = [] as ConversationMessage[];
+
+  function handleFrame(frame: AI.PartiallyRendered[]): AI.Node {
+    if (isAppendOnlyRender) {
+      const delta = toConversationMessages(frame.slice(lastFrame.length));
+      conversationMessages = conversationMessages.concat(delta);
+      lastFrame = frame;
+      return delta.map(present ?? ((m) => m.element));
+    }
+
+    conversationMessages = toConversationMessages(frame);
+    return toConversationMessages(frame).map(present ?? ((m) => m.element));
+  }
+
+  // Memoize before rendering so that the all the conversational components get memoized as well.
+  const finalFrame = yield* render(memo(children), {
+    map: handleFrame,
+    stop: isConversationalComponent,
+    appendOnly: isAppendOnlyRender,
+  });
+
+  // Prioritize rendering by yielding the final frame before running the `onComplete` handler.
+  yield handleFrame(finalFrame);
+  await onComplete?.(conversationMessages, render);
+
+  // N.B. This may not have been an append-only stream until now, but by returning this
+  // we can indicate that we've already yielded the final frame.
+  return AI.AppendOnlyStream;
+}

--- a/packages/ai-jsx/src/core/errors.ts
+++ b/packages/ai-jsx/src/core/errors.ts
@@ -35,6 +35,8 @@ export enum ErrorCode {
   Llama2DoesNotSupportFunctionResponse = 1028,
   Llama2DoesNotSupportMultipleSystemMessages = 1029,
 
+  UnexpectedPartialRenderResult = 1030,
+
   ModelOutputDidNotMatchConstraint = 2000,
 
   UnsupportedMimeType = 2001,

--- a/packages/ai-jsx/src/core/node.ts
+++ b/packages/ai-jsx/src/core/node.ts
@@ -12,6 +12,7 @@ import { Logger } from './log.js';
 /** A context that is used to render an AI.JSX component. */
 export interface ComponentContext extends RenderContext {
   logger: Logger;
+  isAppendOnlyRender: boolean;
 }
 
 /** Represents a single AI.JSX component. */
@@ -32,7 +33,7 @@ export interface Element<P> {
   /** The component properties. */
   props: P;
   /** A function that renders this {@link Element} to a {@link Renderable}. */
-  render: (renderContext: RenderContext, logger: Logger) => Renderable;
+  render: (renderContext: RenderContext, logger: Logger, isAppendOnlyRender: boolean) => Renderable;
   /** The {@link RenderContext} associated with this {@link Element}. */
   [attachedContextSymbol]?: RenderContext;
 }
@@ -119,7 +120,7 @@ export function createElement<P extends { children: C | C[] }, C>(
   const result = {
     tag,
     props: propsToPass,
-    render: (ctx, logger) => tag(propsToPass, { ...ctx, logger }),
+    render: (ctx, logger, isAppendOnlyRender) => tag(propsToPass, { ...ctx, logger, isAppendOnlyRender }),
   } as Element<P>;
   Object.freeze(propsToPass);
   Object.freeze(result);

--- a/packages/ai-jsx/src/core/render.ts
+++ b/packages/ai-jsx/src/core/render.ts
@@ -311,7 +311,7 @@ async function* renderStream(
        */
       logImpl.log('debug', renderable, renderId, 'Start rendering element');
       const finalResult = yield* renderingContext.render(
-        renderable.render(renderingContext, new BoundLogger(logImpl, renderId, renderable)),
+        renderable.render(renderingContext, new BoundLogger(logImpl, renderId, renderable), appendOnly),
         recursiveRenderOpts
       );
       logImpl.log('debug', renderable, renderId, { finalResult }, 'Finished rendering element');

--- a/packages/ai-jsx/src/lib/anthropic.tsx
+++ b/packages/ai-jsx/src/lib/anthropic.tsx
@@ -3,16 +3,8 @@ import { getEnvVar } from './util.js';
 import * as AI from '../index.js';
 import { Node } from '../index.js';
 import { ChatOrCompletionModelOrBoth } from './model.js';
-import {
-  AssistantMessage,
-  ChatProvider,
-  FunctionCall,
-  FunctionResponse,
-  ModelProps,
-  SystemMessage,
-  UserMessage,
-  ModelPropsWithChildren,
-} from '../core/completion.js';
+import { ChatProvider, ModelProps, ModelPropsWithChildren } from '../core/completion.js';
+import { AssistantMessage, ConversationMessage, UserMessage, renderToConversation } from '../core/conversation.js';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
 
 export const anthropicClientContext = AI.createContext<AnthropicSDK>(
@@ -103,47 +95,41 @@ export async function* AnthropicChatModel(
     );
   }
   yield AI.AppendOnlyStream;
-  const messageElements = await render(props.children, {
-    stop: (e) =>
-      e.tag == SystemMessage ||
-      e.tag == UserMessage ||
-      e.tag == AssistantMessage ||
-      e.tag == FunctionCall ||
-      e.tag == FunctionResponse,
-  });
   const messages = await Promise.all(
-    messageElements
-      .filter(AI.isElement)
-      .flatMap((message) => {
-        if (message.tag === SystemMessage) {
+    (
+      await renderToConversation(props.children, render)
+    )
+      .flatMap<Exclude<ConversationMessage, { type: 'system' }>>((message) => {
+        if (message.type === 'system') {
           return [
-            <UserMessage>For subsequent replies you will adhere to the following instructions: {message}</UserMessage>,
-            <AssistantMessage>Okay, I will do that.</AssistantMessage>,
+            {
+              type: 'user',
+              element: (
+                <UserMessage>
+                  For subsequent replies you will adhere to the following instructions: {message.element}
+                </UserMessage>
+              ),
+            },
+            { type: 'assistant', element: <AssistantMessage>Okay, I will do that.</AssistantMessage> },
           ];
         }
 
-        return message;
+        return [message];
       })
       .map(async (message) => {
-        switch (message.tag) {
-          case UserMessage:
-            return `${AnthropicSDK.HUMAN_PROMPT}:${message.props.name ? ` (${message.props.name})` : ''} ${await render(
-              message
-            )}`;
-          case AssistantMessage:
-            return `${AnthropicSDK.AI_PROMPT}: ${await render(message)}`;
-          case FunctionCall:
-          case FunctionResponse:
+        switch (message.type) {
+          case 'user':
+            return `${AnthropicSDK.HUMAN_PROMPT}:${
+              message.element.props.name ? ` (${message.element.props.name})` : ''
+            } ${await render(message.element)}`;
+          case 'assistant':
+            return `${AnthropicSDK.AI_PROMPT}: ${await render(message.element)}`;
+          case 'functionCall':
+          case 'functionResponse':
             throw new AIJSXError(
               'Anthropic models do not support functions.',
               ErrorCode.AnthropicDoesNotSupportFunctions,
               'user'
-            );
-          default:
-            throw new AIJSXError(
-              `ChatCompletion's prompts must be UserMessage or AssistantMessage, but this child was ${message.tag.name}`,
-              ErrorCode.ChatCompletionUnexpectedChild,
-              'internal'
             );
         }
       })

--- a/packages/ai-jsx/tsconfig.json
+++ b/packages/ai-jsx/tsconfig.json
@@ -8,6 +8,7 @@
     "entryPoints": [
       "src/index.ts",
       "src/core/completion.tsx",
+      "src/core/conversation.tsx",
       "src/core/debug.tsx",
       "src/core/error-boundary.ts",
       "src/core/errors.ts",

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.7.1
+## 0.7.2
+
+- Add `Converse` and `ShowConversation` components facilitate streaming conversations.
+
+## [0.7.1](https://github.com/fixie-ai/ai-jsx/commit/058c463a32321d754639dcf44a2b6f3b5a863d1f)
 
 - Change `ChatCompletion` components to render to `<AssistantMessage>` and `<FunctionCall>` elements.
 

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -1,7 +1,7 @@
 import * as math from 'mathjs';
-import { UseTools, Tool } from 'ai-jsx/batteries/use-tools';
+import { Tool, UseTools } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
-import { UserMessage } from 'ai-jsx/core/completion';
+import { UserMessage, ShowConversation } from 'ai-jsx/core/conversation';
 
 function evaluate({ expression }: { expression: string }) {
   return math.evaluate(expression);
@@ -22,9 +22,39 @@ function App({ query }: { query: string }) {
     },
   };
   return (
-    <UseTools showSteps tools={tools} fallback="Failed to evaluate the mathematical expression">
-      <UserMessage>{query}</UserMessage>
-    </UseTools>
+    <ShowConversation
+      present={(msg) => {
+        switch (msg.type) {
+          case 'assistant':
+            return (
+              <>
+                Assistant: {msg.element}
+                {'\n'}
+              </>
+            );
+          case 'functionCall':
+            return (
+              <>
+                Function Call: {msg.element}
+                {'\n'}
+              </>
+            );
+          case 'functionResponse':
+            return (
+              <>
+                Function Result: {msg.element}
+                {'\n'}
+              </>
+            );
+          default:
+            return null;
+        }
+      }}
+    >
+      <UseTools tools={tools} fallback="Failed to evaluate the mathematical expression">
+        <UserMessage>{query}</UserMessage>
+      </UseTools>
+    </ShowConversation>
   );
 }
 

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -51,7 +51,7 @@ function App({ query }: { query: string }) {
         }
       }}
     >
-      <UseTools tools={tools} fallback="Failed to evaluate the mathematical expression">
+      <UseTools showSteps tools={tools} fallback="Failed to evaluate the mathematical expression">
         <UserMessage>{query}</UserMessage>
       </UseTools>
     </ShowConversation>


### PR DESCRIPTION

![image](https://github.com/fixie-ai/ai-jsx/assets/829827/e4cd9745-ad8d-4a92-8585-43b005ea3bce)


- Move conversational components (`UserMessage` et al) to a separate file
- Add `isAppendOnlyRender` to `ComponentContext` to allow components to optimize their stream based on whether they're part of an append-only stream.
- Add `renderToConversation`, `Converse`, and `ShowConversation` helpers/components to facilitate conversational UI

The `UseTools` example demonstrates using `ShowConversation` to manage the presentation.