### PR TITLE
Make `memo` less spammy for logs/instrumentation

### DIFF
--- a/packages/ai-jsx/src/core/debug.tsx
+++ b/packages/ai-jsx/src/core/debug.tsx
@@ -67,7 +67,7 @@ export function debug(value: unknown, expandJSXChildren: boolean = true): string
       const results = [];
 
       if (memoizedId) {
-        results.push(' @memoizedId=' + memoizedId);
+        results.push(` @memoizedId=${memoizedId}`);
       }
 
       if (value.props) {

--- a/packages/ai-jsx/src/core/debug.tsx
+++ b/packages/ai-jsx/src/core/debug.tsx
@@ -6,7 +6,7 @@
 
 import * as AI from '../index.js';
 import { Element, ElementPredicate, Node, RenderContext } from '../index.js';
-import { isMemoizedSymbol } from './memoize.js';
+import { memoizedIdSymbol } from './memoize.js';
 
 const maxStringLength = 1000;
 
@@ -54,19 +54,24 @@ export function debug(value: unknown, expandJSXChildren: boolean = true): string
       const tag = value.tag === AI.Fragment ? '' : typeof value.tag === 'string' ? value.tag : value.tag.name;
       const childIndent = `${indent}  `;
 
-      const isMemoized = isMemoizedSymbol in value.props;
-      const memoizedIsPreviouslyRenderedToDebugOutput = previouslyMemoizedIds.has(value.props.id);
+      const memoizedId = memoizedIdSymbol in value.props && (value.props[memoizedIdSymbol] as number);
+      const memoizedIsPreviouslyRenderedToDebugOutput = memoizedId && previouslyMemoizedIds.has(memoizedId);
 
-      if (isMemoized && !memoizedIsPreviouslyRenderedToDebugOutput) {
-        previouslyMemoizedIds.add(value.props.id);
+      if (memoizedId && !memoizedIsPreviouslyRenderedToDebugOutput) {
+        previouslyMemoizedIds.add(memoizedId);
       }
 
       let children = '';
-      if (expandJSXChildren && (!isMemoized || !memoizedIsPreviouslyRenderedToDebugOutput)) {
+      if (expandJSXChildren && (!memoizedId || !memoizedIsPreviouslyRenderedToDebugOutput)) {
         children = debugRec(value.props.children, childIndent, 'children');
       }
 
       const results = [];
+
+      if (memoizedId) {
+        results.push(' @memoizedId=' + memoizedId);
+      }
+
       if (value.props) {
         for (const key of Object.keys(value.props)) {
           const propValue = value.props[key];

--- a/packages/ai-jsx/src/core/memoize.tsx
+++ b/packages/ai-jsx/src/core/memoize.tsx
@@ -79,7 +79,7 @@ export function partialMemo(renderable: Renderable, existingId?: number): Node |
 
     return {
       [memoizedIdSymbol]: id,
-      [Symbol.asyncIterator]: async function* (): AsyncGenerator<
+      async *[Symbol.asyncIterator](): AsyncGenerator<
         Renderable | typeof AppendOnlyStream,
         Renderable | typeof AppendOnlyStream
       > {

--- a/packages/ai-jsx/src/core/node.ts
+++ b/packages/ai-jsx/src/core/node.ts
@@ -76,7 +76,18 @@ export function makeIndirectNode<T extends object>(value: T, node: Node): T & In
 }
 
 /** @hidden */
-export function withContext(renderable: Renderable, context: RenderContext): Element<any> {
+export function withContext<P>(element: Element<P>, context: RenderContext): Element<P>;
+export function withContext(renderable: Renderable, context: RenderContext): Node;
+export function withContext(renderable: Renderable, context: RenderContext): Node {
+  if (typeof renderable !== 'object' || renderable == null) {
+    // Switching contexts isn't meaningful for scalars.
+    return renderable;
+  }
+
+  if (Array.isArray(renderable)) {
+    return renderable.map((node) => withContext(node, context));
+  }
+
   if (isElement(renderable)) {
     if (renderable[attachedContextSymbol]) {
       // It's already been bound to a context; don't replace it.

--- a/packages/examples/src/inline-completion.tsx
+++ b/packages/examples/src/inline-completion.tsx
@@ -24,4 +24,4 @@ function CharacterGenerator() {
     </Inline>
   );
 }
-showInspector(<CharacterGenerator />);
+showInspector(<CharacterGenerator />, { showDebugTree: false });

--- a/packages/examples/src/inline-completion.tsx
+++ b/packages/examples/src/inline-completion.tsx
@@ -24,4 +24,4 @@ function CharacterGenerator() {
     </Inline>
   );
 }
-showInspector(<CharacterGenerator />, { showDebugTree: false });
+showInspector(<CharacterGenerator />);


### PR DESCRIPTION
This changes `memo` and `withContext` to introduce wrapper elements less aggressively so as not to bloat instrumentation with `<Memoized>`/`<MemoizedGenerator>` et al.

Additionally, change the `memoizedId` semantics so that memoized _subtrees_ are tagged with the same memoization ID, rather than assigning new IDs at each layer. This will be used subsequently to allow instrumentation to associate each memoized subtree to a single asynchronous render (drastically improving instrumentation legibility).