### PR TITLE
Add explicit prompt/completion logging/attributes, skip tracing for synchronous components

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -155,22 +155,16 @@ export class CombinedLogger extends LogImplementation {
     super();
   }
 
-  log(
-    level: LogLevel,
-    element: Element<any>,
-    renderId: string,
-    metadataOrMessage: string | object,
-    message?: string | undefined
-  ): void {
-    this.loggers.forEach((l) => l.log(level, element, renderId, metadataOrMessage, message));
+  log(...args: Parameters<LogImplementation['log']>): void {
+    this.loggers.forEach((l) => l.log(...args));
   }
 
-  logException(element: Element<object>, renderId: string, exception: unknown): void {
-    this.loggers.forEach((l) => l.logException(element, renderId, exception));
+  logException(...args: Parameters<LogImplementation['logException']>): void {
+    this.loggers.forEach((l) => l.logException(...args));
   }
 
-  setAttribute(element: Element<any>, renderId: string, key: string, value: string): void {
-    this.loggers.forEach((l) => l.setAttribute(element, renderId, key, value));
+  setAttribute(...args: Parameters<LogImplementation['setAttribute']>): void {
+    this.loggers.forEach((l) => l.setAttribute(...args));
   }
 }
 

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -6,6 +6,7 @@
 import _ from 'lodash';
 import pino from 'pino';
 import { Element } from './node.js';
+import opentelemetry from '@opentelemetry/api';
 import { logs, type Logger as OpenTelemetryLoggerInterface } from '@opentelemetry/api-logs';
 import { getEnvVar } from '../lib/util.js';
 
@@ -14,7 +15,9 @@ export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
 /**
  * A Logger represents an object that can log messages.
  */
-export type Logger = Record<LogLevel, (obj: object | string, msg?: string) => void>;
+export type Logger = Record<LogLevel, (obj: object | string, msg?: string) => void> & {
+  setAttribute: (key: string, value: string) => void;
+};
 
 /**
  * An abstract class that represents an implementation of {@link Logger}.
@@ -64,6 +67,11 @@ export abstract class LogImplementation {
       `Rendering element ${elementTag} failed with exception: ${exception}`
     );
   }
+
+  /**
+   * Sets an attribute to be associated with the rendering of a particular element.
+   */
+  setAttribute(_element: Element<any>, _renderId: string, _key: string, _value: string) {}
 }
 
 /**
@@ -129,6 +137,14 @@ export class OpenTelemetryLogger extends LogImplementation {
       },
     });
   }
+
+  setAttribute(element: Element<any>, renderId: string, key: string, value: string): void {
+    // Set the attribute on the current span.
+    const span = opentelemetry.trace.getActiveSpan();
+    if (span) {
+      span.setAttribute(key, value);
+    }
+  }
 }
 
 /**
@@ -152,6 +168,10 @@ export class CombinedLogger extends LogImplementation {
   logException(element: Element<object>, renderId: string, exception: unknown): void {
     this.loggers.forEach((l) => l.logException(element, renderId, exception));
   }
+
+  setAttribute(element: Element<any>, renderId: string, key: string, value: string): void {
+    this.loggers.forEach((l) => l.setAttribute(element, renderId, key, value));
+  }
 }
 
 /**
@@ -170,4 +190,5 @@ export class BoundLogger implements Logger {
   info = (obj: object | string, msg?: string) => this.impl.log('info', this.element, this.renderId, obj, msg);
   debug = (obj: object | string, msg?: string) => this.impl.log('debug', this.element, this.renderId, obj, msg);
   trace = (obj: object | string, msg?: string) => this.impl.log('trace', this.element, this.renderId, obj, msg);
+  setAttribute = (key: string, value: string) => this.impl.setAttribute(this.element, this.renderId, key, value);
 }

--- a/packages/ai-jsx/src/core/opentelemetry.ts
+++ b/packages/ai-jsx/src/core/opentelemetry.ts
@@ -3,10 +3,9 @@ import { PartiallyRendered, StreamRenderer } from './render.js';
 import { Element, isElement } from './node.js';
 import { memoizedIdSymbol } from './memoize.js';
 import { debug } from './debug.js';
-import { getEncoding } from 'js-tiktoken';
-import _ from 'lodash';
+import { getEnvVar } from '../lib/util.js';
 
-function bindAsyncGeneratorToActiveContext<T = unknown, TReturn = any, TNext = unknown>(
+export function bindAsyncGeneratorToActiveContext<T = unknown, TReturn = any, TNext = unknown>(
   generator: AsyncGenerator<T, TReturn, TNext>
 ): AsyncGenerator<T, TReturn, TNext> {
   const activeContext = context.active();
@@ -31,6 +30,10 @@ interface MemoizedIdAndOwner {
   isOwner: boolean;
 }
 
+// Indicates whether we're currently tracing _any_ component so that we can skip
+// tracing non-root synchronous components.
+const isTracingComponent = createContextKey('Whether the current async context is tracing a component');
+
 // Indicates whether the current async context is responsible for tracing the memoized subtree.
 const activeMemoizedIdStorage = createContextKey('The active MemoizedIdAndOwner');
 
@@ -38,17 +41,26 @@ function spanAttributesForElement(element: Element<any>): opentelemetry.Attribut
   return { 'ai.jsx.tag': element.tag.name, 'ai.jsx.tree': debug(element, true) };
 }
 
-const getEncoder = _.once(() => getEncoding('cl100k_base'));
-
 export function openTelemetryStreamRenderer(streamRenderer: StreamRenderer): StreamRenderer {
+  const traceEveryComponent = Boolean(getEnvVar('AIJSX_OPENTELEMETRY_TRACE_ALL', false));
   const tracer = opentelemetry.trace.getTracer('ai.jsx');
 
-  return (renderContext, renderable, shouldStop, appendOnly) => {
+  const wrappedRender: StreamRenderer = (renderContext, renderable, shouldStop, appendOnly) => {
     if (!isElement(renderable)) {
       return streamRenderer(renderContext, renderable, shouldStop, appendOnly);
     }
 
-    const activeContext = context.active();
+    let activeContext = context.active();
+    if (!traceEveryComponent && renderable.tag.constructor === Function && activeContext.getValue(isTracingComponent)) {
+      // Don't trace synchronous functions, though note that this also means that non-async
+      // functions that simply return promises won't be traced.
+      return streamRenderer(renderContext, renderable, shouldStop, appendOnly);
+    }
+
+    if (!activeContext.getValue(isTracingComponent)) {
+      activeContext = activeContext.setValue(isTracingComponent, true);
+    }
+
     let startup = (_span: opentelemetry.Span) => {};
     let cleanup = (_span: opentelemetry.Span) => {};
     const renderInSpan = (span: opentelemetry.Span) => {
@@ -66,9 +78,6 @@ export function openTelemetryStreamRenderer(streamRenderer: StreamRenderer): Str
             const resultIsPartial = result.find(isElement);
             // Record the rendered value.
             span.setAttribute('ai.jsx.result', resultIsPartial ? debug(result, true) : result.join(''));
-            if (!resultIsPartial) {
-              span.setAttribute('ai.jsx.result.tokenCount', getEncoder().encode(result.join('')).length);
-            }
           }
           cleanup(span);
           span.end();
@@ -91,13 +100,11 @@ export function openTelemetryStreamRenderer(streamRenderer: StreamRenderer): Str
         // Nothing is currently tracing this memoized subtree.
         startup = (span) => memoizedIdsToActiveSpanContexts.set(memoizedId, span.spanContext());
         cleanup = () => memoizedIdsToActiveSpanContexts.delete(memoizedId);
-        const newContext = activeContext.setValue(activeMemoizedIdStorage, { id: memoizedId, isOwner: true });
-        return context.with(newContext, () =>
-          tracer.startActiveSpan(
-            `<${renderable.tag.name}>`,
-            { attributes: spanAttributesForElement(renderable) },
-            renderInSpan
-          )
+        return tracer.startActiveSpan(
+          `<${renderable.tag.name}>`,
+          { attributes: spanAttributesForElement(renderable) },
+          activeContext.setValue(activeMemoizedIdStorage, { id: memoizedId, isOwner: true }),
+          renderInSpan
         );
       }
 
@@ -107,16 +114,14 @@ export function openTelemetryStreamRenderer(streamRenderer: StreamRenderer): Str
       if (activeMemoizedIdAndOwner === undefined || activeMemoizedIdAndOwner.id !== memoizedId) {
         // We're entering a memoized subtree that's already being actively rendered. Create a
         // span that shows that we're blocked on the memoized subtree.
-        const newContext = context.active().setValue(activeMemoizedIdStorage, { id: memoizedId, isOwner: false });
-        return context.with(newContext, () =>
-          tracer.startActiveSpan(
-            `<Memoized.${renderable.tag.name}>`,
-            {
-              attributes: { 'ai.jsx.memoized': true, ...spanAttributesForElement(renderable) },
-              links: [{ context: activeSpanContext }],
-            },
-            renderInSpan
-          )
+        return tracer.startActiveSpan(
+          `<Memoized.${renderable.tag.name}>`,
+          {
+            attributes: { 'ai.jsx.memoized': true, ...spanAttributesForElement(renderable) },
+            links: [{ context: activeSpanContext }],
+          },
+          activeContext.setValue(activeMemoizedIdStorage, { id: memoizedId, isOwner: false }),
+          renderInSpan
         );
       }
 
@@ -131,7 +136,10 @@ export function openTelemetryStreamRenderer(streamRenderer: StreamRenderer): Str
     return tracer.startActiveSpan(
       `<${renderable.tag.name}>`,
       { attributes: spanAttributesForElement(renderable) },
+      activeContext,
       renderInSpan
     );
   };
+
+  return wrappedRender;
 }

--- a/packages/ai-jsx/src/core/render.ts
+++ b/packages/ai-jsx/src/core/render.ts
@@ -311,10 +311,19 @@ async function* renderStream(
     const logImpl = renderingContext.getContext(LoggerContext);
     const renderId = uuidv4();
     try {
+      /**
+       * This approach is pretty noisy because there are many internal components about which the users don't care.
+       * For instance, if the user writes <ChatCompletion>, that'll generate a bunch of internal helpers to
+       * locate + call the model provider, etc.
+       *
+       * To get around this, maybe we want components to be able to choose the loglevel used for their rendering.
+       */
+      logImpl.log('debug', renderable, renderId, 'Start rendering element');
       const finalResult = yield* renderingContext.render(
         renderable.render(renderingContext, new BoundLogger(logImpl, renderId, renderable), appendOnly),
         recursiveRenderOpts
       );
+      logImpl.log('debug', renderable, renderId, { finalResult }, 'Finished rendering element');
       return finalResult;
     } catch (ex) {
       logImpl.logException(renderable, renderId, ex);

--- a/packages/ai-jsx/src/core/render.ts
+++ b/packages/ai-jsx/src/core/render.ts
@@ -43,7 +43,7 @@ export const AppendOnlyStream = Symbol('AI.appendOnlyStream');
  * A RenderableStream represents an async iterable that yields {@link Renderable}s.
  */
 export interface RenderableStream {
-  [Symbol.asyncIterator]: () => AsyncIterator<
+  [Symbol.asyncIterator]: () => AsyncGenerator<
     Renderable | typeof AppendOnlyStream,
     Renderable | typeof AppendOnlyStream
   >;
@@ -311,19 +311,10 @@ async function* renderStream(
     const logImpl = renderingContext.getContext(LoggerContext);
     const renderId = uuidv4();
     try {
-      /**
-       * This approach is pretty noisy because there are many internal components about which the users don't care.
-       * For instance, if the user writes <ChatCompletion>, that'll generate a bunch of internal helpers to
-       * locate + call the model provider, etc.
-       *
-       * To get around this, maybe we want components to be able to choose the loglevel used for their rendering.
-       */
-      logImpl.log('debug', renderable, renderId, 'Start rendering element');
       const finalResult = yield* renderingContext.render(
         renderable.render(renderingContext, new BoundLogger(logImpl, renderId, renderable), appendOnly),
         recursiveRenderOpts
       );
-      logImpl.log('debug', renderable, renderId, { finalResult }, 'Finished rendering element');
       return finalResult;
     } catch (ex) {
       logImpl.logException(renderable, renderId, ex);

--- a/packages/ai-jsx/src/lib/replicate-llama2.tsx
+++ b/packages/ai-jsx/src/lib/replicate-llama2.tsx
@@ -78,7 +78,7 @@ export async function* Llama2ChatModel(
   yield AI.AppendOnlyStream;
 
   // TODO: Support token budget/conversation shrinking
-  const messageElements = await renderToConversation(props.children, render);
+  const messageElements = await renderToConversation(props.children, render, logger, 'prompt');
   const systemMessage = messageElements.filter((e) => e.type == 'system');
   const userMessages = messageElements.filter((e) => e.type == 'user');
   if (systemMessage.length > 1) {
@@ -126,7 +126,7 @@ export async function* Llama2ChatModel(
     prompt: await render(userMessages[0].element),
     system_prompt: systemMessage.length ? await render(systemMessage[0].element) : undefined,
   };
-  yield (
+  const assistantMessage = (
     <AssistantMessage>
       {await fetchLlama2(
         'replicate/llama70b-v2-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48',
@@ -135,6 +135,10 @@ export async function* Llama2ChatModel(
       )}
     </AssistantMessage>
   );
+  yield assistantMessage;
+
+  // Render it so that the conversation is logged.
+  await renderToConversation(assistantMessage, render, logger, 'completion');
   return AI.AppendOnlyStream;
 }
 

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.9.1
+## 0.9.2
+
+- In the [OpenTelemetry integration](./guides/observability.md#opentelemetry-integration):
+  - Add prompt/completion attributes with token counts for `<OpenAIChatModel>`. This replaces the `tokenCount` attribute added in 0.9.1.
+  - By default, only emit spans for `async` components.
+
+## [0.9.1](https://github.com/fixie-ai/ai-jsx/commit/0d2e6d8ecd1c75b457d0d6c76ff854c9145a9f5f)
 
 - Add `tokenCount` field to [OpenTelemetry-emitted spans](./guides/observability.md#opentelemetry-integration). Now, if you're emitting via OpenTelemetry (e.g. to DataDog), the spans will tell you how many tokens each component resolved to. This is helpful for answering quetsions like "how big is my system message?".
 

--- a/packages/docs/docs/guides/observability.md
+++ b/packages/docs/docs/guides/observability.md
@@ -184,11 +184,13 @@ This technique uses the [context affordance](./rules-of-jsx.md#context).
 
 [OpenTelemetry](https://opentelemetry.io/) is an open source observability framework that is supported by [a number of vendors](https://opentelemetry.io/ecosystem/vendors/).
 AI.JSX includes an integration with OpenTelemetry to trace rendering. To enable it, set the `AIJSX_ENABLE_OPENTELEMETRY` environment variable to `1`. When enabled,
-[Spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans) are emitted for each element and capture:
+[Spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans) are emitted for each `async` component and capture:
 
 - The input and output of each element
 - Dependencies between elements
 - The latency of each element
+
+To trace both `async` and synchronous components, set the `AIJSX_OPENTELEMETRY_TRACE_ALL` environment variable to `1`.
 
 Logs are automatically emitted to OpenTelemetry as well.
 

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -57,9 +57,7 @@ describe('OpenTelemetry', () => {
   });
   sdk.start();
 
-  afterAll(async () => {
-    await sdk.shutdown();
-  });
+  afterAll(() => sdk.shutdown());
 
   beforeEach(() => {
     memoryExporter.reset();

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -127,6 +127,137 @@ describe('OpenTelemetry', () => {
         },
       ]
     `);
+
+    // Test with AIJSX_OPENTELEMETRY_TRACE_ALL
+    memoryExporter.reset();
+    process.env.AIJSX_OPENTELEMETRY_TRACE_ALL = '1';
+    await AI.createRenderContext({ enableOpenTelemetry: true }).render(
+      <ChatCompletion>
+        <UserMessage>hello</UserMessage>
+      </ChatCompletion>
+    );
+
+    expect(_.map(memoryExporter.getFinishedSpans(), 'attributes')).toMatchInlineSnapshot(`
+      [
+        {
+          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>]",
+          "ai.jsx.tag": "UserMessage",
+          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>",
+        },
+        {
+          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>]",
+          "ai.jsx.tag": "UserMessage",
+          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>",
+        },
+        {
+          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>]",
+          "ai.jsx.tag": "ShrinkConversation",
+          "ai.jsx.tree": "<ShrinkConversation cost={tokenCountForConversationMessage} budget={4093}>
+        <UserMessage>
+          {"hello"}
+        </UserMessage>
+      </ShrinkConversation>",
+        },
+        {
+          "ai.jsx.result": "hello",
+          "ai.jsx.tag": "UserMessage",
+          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>",
+        },
+        {
+          "ai.jsx.result": "hello",
+          "ai.jsx.tag": "UserMessage",
+          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+        {"hello"}
+      </UserMessage>",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "Stream",
+          "ai.jsx.tree": ""▮"",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "AssistantMessage",
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+        {"▮"}
+      </AssistantMessage>",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "Stream",
+          "ai.jsx.tree": ""opentel response from OpenAI"",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "AssistantMessage",
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+        {"opentel response from OpenAI"}
+      </AssistantMessage>",
+        },
+        {
+          "ai.jsx.result": "[<AssistantMessage @memoizedId=4>
+        {"opentel response from OpenAI"}
+      </AssistantMessage>]",
+          "ai.jsx.tag": "AssistantMessage",
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+        {"opentel response from OpenAI"}
+      </AssistantMessage>",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "Stream",
+          "ai.jsx.tree": ""opentel response from OpenAI"",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "AssistantMessage",
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+        {"opentel response from OpenAI"}
+      </AssistantMessage>",
+        },
+        {
+          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=4>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
+          "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=3>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "OpenAIChatModel",
+          "ai.jsx.tree": "<OpenAIChatModel model="gpt-3.5-turbo">
+        <UserMessage>
+          {"hello"}
+        </UserMessage>
+      </OpenAIChatModel>",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "AutomaticChatModel",
+          "ai.jsx.tree": "<AutomaticChatModel>
+        <UserMessage>
+          {"hello"}
+        </UserMessage>
+      </AutomaticChatModel>",
+        },
+        {
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "ChatCompletion",
+          "ai.jsx.tree": "<ChatCompletion>
+        <UserMessage>
+          {"hello"}
+        </UserMessage>
+      </ChatCompletion>",
+        },
+      ]
+    `);
   });
 });
 


### PR DESCRIPTION
1. Add explicit (conversational) prompt/completion logging and span attributes, including token counts
2. Skip OpenTelemetry tracing for non-root synchronous components, which drastically simplifies the traces
3. Remove universal `ai.jsx.result.tokenCount` span attribute, which doesn't have the opportunity to handle conversational messages correctly