### PR TITLE
Add ability to reserve tokens without (statically) limiting response length

### DIFF
--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -30,6 +30,8 @@ export interface ModelProps {
   temperature?: number;
   /** The maximum number of tokens to generate. */
   maxTokens?: number;
+  /** The number of tokens to reserve for the generation. */
+  reservedTokens?: number;
   /** A list of stop tokens. */
   stop?: string[];
 

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -398,9 +398,9 @@ export async function* OpenAIChatModel(
 
   let promptTokenLimit = tokenLimitForChatModel(props.model, props.functionDefinitions);
 
-  // If maxTokens is set, reserve that many tokens for the reply.
-  if (promptTokenLimit !== undefined && props.maxTokens) {
-    promptTokenLimit -= props.maxTokens;
+  // If reservedTokens (or maxTokens) is set, reserve that many tokens for the reply.
+  if (promptTokenLimit !== undefined) {
+    promptTokenLimit -= props.reservedTokens ?? props.maxTokens ?? 0;
   }
 
   const conversationMessages = await renderToConversation(

--- a/packages/examples/test/lib/openai.tsx
+++ b/packages/examples/test/lib/openai.tsx
@@ -1,0 +1,83 @@
+import * as AI from 'ai-jsx';
+import { ChatCompletion } from 'ai-jsx/core/completion';
+import { Shrinkable, UserMessage } from 'ai-jsx/core/conversation';
+import { OpenAI, SSE_FINAL_EVENT, SSE_PREFIX, SSE_TERMINATOR } from 'ai-jsx/lib/openai';
+import { Jsonifiable } from 'type-fest';
+
+describe('OpenAIChatModel', () => {
+  it('honors the maxTokens prop', async () => {
+    const ctx = AI.createRenderContext();
+    const result = await ctx.render(
+      <OpenAI
+        chatModel="gpt-3.5-turbo"
+        client={{
+          ...({} as any),
+          createChatCompletion: async (req) => {
+            expect(req.max_tokens).toBe(4096);
+            expect(req.messages).toEqual([
+              expect.objectContaining({
+                content: 'Hello!',
+              }),
+            ]);
+
+            return new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
+              status: 200,
+            });
+          },
+        }}
+      >
+        <ChatCompletion maxTokens={4096}>
+          <Shrinkable importance={0} replacement={<UserMessage>Hello!</UserMessage>}>
+            <UserMessage>This should be replaced</UserMessage>
+          </Shrinkable>
+        </ChatCompletion>
+      </OpenAI>
+    );
+
+    expect(result).toBe('Hi!');
+  });
+
+  it('honors the reservedTokens prop', async () => {
+    const ctx = AI.createRenderContext();
+    const result = await ctx.render(
+      <OpenAI
+        chatModel="gpt-3.5-turbo"
+        client={{
+          ...({} as any),
+          createChatCompletion: async (req) => {
+            expect(req.max_tokens).toBe(undefined);
+            expect(req.messages).toEqual([
+              expect.objectContaining({
+                content: 'Hello!',
+              }),
+            ]);
+
+            return new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
+              status: 200,
+            });
+          },
+        }}
+      >
+        <ChatCompletion reservedTokens={4096}>
+          <Shrinkable importance={0} replacement={<UserMessage>Hello!</UserMessage>}>
+            <UserMessage>This should be replaced</UserMessage>
+          </Shrinkable>
+        </ChatCompletion>
+      </OpenAI>
+    );
+
+    expect(result).toBe('Hi!');
+  });
+});
+
+function jsonToOpenAIStream(messages: Jsonifiable[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const message of messages) {
+        controller.enqueue(`${SSE_PREFIX}${JSON.stringify(message)}${SSE_TERMINATOR}`);
+      }
+      controller.enqueue(`${SSE_PREFIX}${SSE_FINAL_EVENT}`);
+      controller.close();
+    },
+  }).pipeThrough(new TextEncoderStream());
+}

--- a/packages/examples/test/lib/openai.tsx
+++ b/packages/examples/test/lib/openai.tsx
@@ -12,7 +12,7 @@ describe('OpenAIChatModel', () => {
         chatModel="gpt-3.5-turbo"
         client={{
           ...({} as any),
-          createChatCompletion: async (req) => {
+          createChatCompletion: (req) => {
             expect(req.max_tokens).toBe(4096);
             expect(req.messages).toEqual([
               expect.objectContaining({
@@ -20,9 +20,11 @@ describe('OpenAIChatModel', () => {
               }),
             ]);
 
-            return new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
-              status: 200,
-            });
+            return Promise.resolve(
+              new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
+                status: 200,
+              })
+            );
           },
         }}
       >
@@ -44,7 +46,7 @@ describe('OpenAIChatModel', () => {
         chatModel="gpt-3.5-turbo"
         client={{
           ...({} as any),
-          createChatCompletion: async (req) => {
+          createChatCompletion: (req) => {
             expect(req.max_tokens).toBe(undefined);
             expect(req.messages).toEqual([
               expect.objectContaining({
@@ -52,9 +54,11 @@ describe('OpenAIChatModel', () => {
               }),
             ]);
 
-            return new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
-              status: 200,
-            });
+            return Promise.resolve(
+              new Response(jsonToOpenAIStream([{ choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] }]), {
+                status: 200,
+              })
+            );
           },
         }}
       >


### PR DESCRIPTION
Add a `reservedTokens` prop to allow consumers to reserve a certain number of tokens for the response without unconditionally limiting the response length. Assuming token estimation is perfectly accurate (and that `reservedTokens < maxTokens`) this means that:
- The response will never be cut off before `reservedTokens`
- The response _may_ be cut off between `reservedTokens` and `maxTokens`
- The response will never exceed `maxTokens`

Consumers may also set `maxTokens` _less_ than `reservedTokens` to set an upper bound on the total number of input/output tokens (e.g. to constrain costs). The upper bound is `context size - reserved tokens + max tokens`.