### PR TITLE
Change memo to no longer replay streams

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -279,7 +279,7 @@ export async function* Converse(
   yield AI.AppendOnlyStream;
 
   const fullConversation = [] as ConversationMessage[];
-  let next = memo(children);
+  let next = children;
   while (true) {
     const newMessages = await renderToConversation(next, render, logger);
     if (newMessages.length === 0) {
@@ -319,7 +319,7 @@ export async function* ShowConversation(
     present?: (message: ConversationMessage) => AI.Node;
     onComplete?: (conversation: ConversationMessage[], render: AI.RenderContext['render']) => Promise<void> | void;
   },
-  { render, isAppendOnlyRender, memo }: AI.ComponentContext
+  { render, isAppendOnlyRender }: AI.ComponentContext
 ): AI.RenderableStream {
   // If we're in an append-only render, do the transformation in an append-only manner so as not to block.
   if (isAppendOnlyRender) {
@@ -341,8 +341,7 @@ export async function* ShowConversation(
     return toConversationMessages(frame).map(present ?? ((m) => m.element));
   }
 
-  // Memoize before rendering so that the all the conversational components get memoized as well.
-  const finalFrame = yield* render(memo(children), {
+  const finalFrame = yield* render(children, {
     map: handleFrame,
     stop: isConversationalComponent,
     appendOnly: isAppendOnlyRender,
@@ -399,7 +398,7 @@ export async function ShrinkConversation(
     budget: number;
     children: Node;
   },
-  { render, memo, logger }: AI.ComponentContext
+  { render, logger }: AI.ComponentContext
 ) {
   /**
    * We construct a tree of immutable and shrinkable nodes such that shrinkable nodes
@@ -513,9 +512,7 @@ export async function ShrinkConversation(
     return roots.map((root) => (root.type === 'immutable' ? root.element : treeRootsToNode(root.children)));
   }
 
-  const memoized = memo(children);
-
-  const rendered = await render(memoized, {
+  const rendered = await render(children, {
     stop: (e) => isConversationalComponent(e) || e.tag === InternalShrinkable,
   });
 

--- a/packages/ai-jsx/src/core/memoize.tsx
+++ b/packages/ai-jsx/src/core/memoize.tsx
@@ -1,9 +1,16 @@
-import { Renderable, RenderContext, AppendOnlyStream, RenderableStream } from './render.js';
-import { Node, getReferencedNode, isIndirectNode, makeIndirectNode, isElement } from './node.js';
+import {
+  Renderable,
+  RenderContext,
+  AppendOnlyStream,
+  RenderableStream,
+  AppendOnlyStreamValue,
+  isAppendOnlyStreamValue,
+  valueToAppend,
+} from './render.js';
+import { Node, Element, getReferencedNode, isIndirectNode, makeIndirectNode, isElement } from './node.js';
 import { Logger } from './log.js';
 import { bindAsyncGeneratorToActiveContext } from './opentelemetry.js';
 
-let lastMemoizedId = 0;
 /** @hidden */
 export const memoizedIdSymbol = Symbol('memoizedId');
 
@@ -12,10 +19,10 @@ export const memoizedIdSymbol = Symbol('memoizedId');
  * "Partially" memoizes a renderable such that it will only be rendered once in any
  * single `RenderContext`.
  */
-export function partialMemo(node: Node, existingId?: number): Node;
-export function partialMemo(renderable: Renderable, existingId?: number): Renderable;
-export function partialMemo(renderable: Renderable, existingId?: number): Node | Renderable {
-  const id = existingId ?? ++lastMemoizedId;
+export function partialMemo<T>(element: Element<T>, id: number): Element<T>;
+export function partialMemo(node: Node, id: number): Node;
+export function partialMemo(renderable: Renderable, id: number): Renderable;
+export function partialMemo(renderable: Renderable, id: number): Node | Renderable {
   if (typeof renderable !== 'object' || renderable === null) {
     return renderable;
   }
@@ -76,32 +83,53 @@ export function partialMemo(renderable: Renderable, existingId?: number): Node |
 
     // N.B. Async context doesn't get bound to the generator, so we need to do that manually.
     const generator = bindAsyncGeneratorToActiveContext(unboundGenerator);
-    const sink: (Renderable | typeof AppendOnlyStream)[] = [];
-    let finalResult: Renderable | typeof AppendOnlyStream = null;
+    const sink: (Node | AppendOnlyStreamValue)[] = [];
+
     let completed = false;
     let nextPromise: Promise<void> | null = null;
 
     return {
       [memoizedIdSymbol]: id,
-      async *[Symbol.asyncIterator](): AsyncGenerator<
-        Renderable | typeof AppendOnlyStream,
-        Renderable | typeof AppendOnlyStream
-      > {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Node | AppendOnlyStreamValue, Node | AppendOnlyStreamValue> {
         let index = 0;
+        let isAppendOnly = false;
+
         while (true) {
           if (index < sink.length) {
-            yield sink[index++];
+            // There's something we can yield/return right away.
+            let nodes = [] as Node[];
+            while (index < sink.length) {
+              let value = sink[index++];
+              if (isAppendOnlyStreamValue(value)) {
+                isAppendOnly = true;
+                value = valueToAppend(value);
+              }
+
+              if (!isAppendOnly) {
+                nodes = [value];
+              } else {
+                nodes.push(value);
+              }
+            }
+
+            const valueToYield = isAppendOnly ? AppendOnlyStream(nodes) : nodes;
+            if (completed) {
+              return valueToYield;
+            }
+
+            yield valueToYield;
             continue;
-          } else if (completed) {
-            return finalResult;
-          } else if (nextPromise == null) {
+          }
+
+          if (nextPromise == null) {
             nextPromise = generator.next().then((result) => {
-              const memoized = result.value === AppendOnlyStream ? result.value : partialMemo(result.value, id);
+              const memoized = isAppendOnlyStreamValue(result.value)
+                ? AppendOnlyStream(partialMemo(valueToAppend(result.value), id))
+                : partialMemo(result.value, id);
+
+              sink.push(memoized);
               if (result.done) {
                 completed = true;
-                finalResult = memoized;
-              } else {
-                sink.push(memoized);
               }
               nextPromise = null;
             });

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.9.2
+## 0.10.0
+
+- Memoized streaming elements no longer replay their entire stream with every render. Instead, they start with the last rendered frame.
+- Elements returned by partial rendering are automatically memoized to ensure they only render once.
+- Streaming components can no longer yield promises or generators. Only `Node`s or `AI.AppendOnlyStream` values can be yielded.
+- The `AI.AppendOnlyStream` value is now a function that can be called with a non-empty value to append.
+
+## [0.9.2](https://github.com/fixie-ai/ai-jsx/commit/219aebeb5e062bf3470a239443626915e0503ad9)
 
 - In the [OpenTelemetry integration](./guides/observability.md#opentelemetry-integration):
   - Add prompt/completion attributes with token counts for `<OpenAIChatModel>`. This replaces the `tokenCount` attribute added in 0.9.1.

--- a/packages/docs/docs/guides/rendering.md
+++ b/packages/docs/docs/guides/rendering.md
@@ -362,3 +362,5 @@ function MyUserMessages() {
   </>
 </ChatCompletion>;
 ```
+
+Elements returned by partial rendering will be [memoized](./rules-of-jsx.md#memoization) so that they render only once.

--- a/packages/docs/docs/guides/rules-of-jsx.md
+++ b/packages/docs/docs/guides/rules-of-jsx.md
@@ -111,7 +111,7 @@ function* GenerateImage() {
 
 AI.JSX will interpret each `yield`ed value as a new value which should totally overwrite the previously-yielded values, so the caller would see a progression of increasingly high-quality images.
 
-However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/core_render.md#appendonlystream) symbol to indicate that `yield`ed results should be interpreted as deltas:
+However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/core_render.md#appendonlystream) value to indicate that `yield`ed results should be interpreted as deltas:
 
 ```tsx
 import * as AI from 'ai-jsx';
@@ -226,6 +226,12 @@ const catName = memo(
 ```
 
 Now, `catName` will result in a single model call, and its value will be reused everywhere that component appears in the tree.
+
+:::note Memoized Streams
+
+If a streaming element is memoized, rendering will start with the last rendered frame rather than replaying every frame.
+
+:::
 
 # See Also
 

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -75,8 +75,6 @@ describe('OpenTelemetry', () => {
 
     const spans = memoryExporter.getFinishedSpans();
     const minimalSpans = _.map(spans, 'attributes');
-    // Unfortunately, the @memoizedId will be sensitive how many tests in this file ran before it.
-    // To avoid issues with that, we put this test first.
     expect(minimalSpans).toMatchInlineSnapshot(`
       [
         {
@@ -106,7 +104,7 @@ describe('OpenTelemetry', () => {
           "ai.jsx.tree": ""opentel response from OpenAI"",
         },
         {
-          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=2>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
+          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=3>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
           "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=1>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "OpenAIChatModel",
@@ -140,25 +138,25 @@ describe('OpenTelemetry', () => {
     expect(_.map(memoryExporter.getFinishedSpans(), 'attributes')).toMatchInlineSnapshot(`
       [
         {
-          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+          "ai.jsx.result": "[<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>]",
           "ai.jsx.tag": "UserMessage",
-          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+          "ai.jsx.tree": "<UserMessage>
         {"hello"}
       </UserMessage>",
         },
         {
-          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+          "ai.jsx.result": "[<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>]",
           "ai.jsx.tag": "UserMessage",
-          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+          "ai.jsx.tree": "<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>",
         },
         {
-          "ai.jsx.result": "[<UserMessage @memoizedId=3>
+          "ai.jsx.result": "[<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>]",
           "ai.jsx.tag": "ShrinkConversation",
@@ -171,14 +169,14 @@ describe('OpenTelemetry', () => {
         {
           "ai.jsx.result": "hello",
           "ai.jsx.tag": "UserMessage",
-          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+          "ai.jsx.tree": "<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>",
         },
         {
           "ai.jsx.result": "hello",
           "ai.jsx.tag": "UserMessage",
-          "ai.jsx.tree": "<UserMessage @memoizedId=3>
+          "ai.jsx.tree": "<UserMessage @memoizedId=1>
         {"hello"}
       </UserMessage>",
         },
@@ -190,7 +188,7 @@ describe('OpenTelemetry', () => {
         {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "AssistantMessage",
-          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
         {"▮"}
       </AssistantMessage>",
         },
@@ -202,16 +200,16 @@ describe('OpenTelemetry', () => {
         {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "AssistantMessage",
-          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
         {"opentel response from OpenAI"}
       </AssistantMessage>",
         },
         {
-          "ai.jsx.result": "[<AssistantMessage @memoizedId=4>
+          "ai.jsx.result": "[<AssistantMessage @memoizedId=3>
         {"opentel response from OpenAI"}
       </AssistantMessage>]",
           "ai.jsx.tag": "AssistantMessage",
-          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
         {"opentel response from OpenAI"}
       </AssistantMessage>",
         },
@@ -223,13 +221,13 @@ describe('OpenTelemetry', () => {
         {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "AssistantMessage",
-          "ai.jsx.tree": "<AssistantMessage @memoizedId=4>
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
         {"opentel response from OpenAI"}
       </AssistantMessage>",
         },
         {
-          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=4>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
-          "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=3>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
+          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=3>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
+          "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=1>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "OpenAIChatModel",
           "ai.jsx.tree": "<OpenAIChatModel model="gpt-3.5-turbo">

--- a/packages/examples/test/core/memoize.tsx
+++ b/packages/examples/test/core/memoize.tsx
@@ -1,0 +1,186 @@
+import * as AI from 'ai-jsx';
+
+it('ensures that elements are only rendered once', async () => {
+  let didRender = false;
+  function Component() {
+    if (didRender) {
+      return 'FAIL';
+    }
+
+    didRender = true;
+    return 'PASS';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+  expect(await ctx.render(element)).toBe('PASS');
+  expect(await ctx.render(element)).toBe('PASS');
+});
+
+it('works with nested components', async () => {
+  let didRender = false;
+  function Component() {
+    if (didRender) {
+      return 'FAIL';
+    }
+
+    didRender = true;
+    return 'PASS';
+  }
+
+  function Parent() {
+    return (
+      <>
+        <Component />
+      </>
+    );
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Parent />);
+  expect(await ctx.render(element)).toBe('PASS');
+  expect(await ctx.render(element)).toBe('PASS');
+});
+
+it('works with nested/async components', async () => {
+  let didRender = false;
+  function Component() {
+    if (didRender) {
+      return 'FAIL';
+    }
+
+    didRender = true;
+    return 'PASS';
+  }
+
+  function AsyncParent() {
+    return Promise.resolve(
+      <>
+        <Component />
+      </>
+    );
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<AsyncParent />);
+  expect(await ctx.render(element)).toBe('PASS');
+  expect(await ctx.render(element)).toBe('PASS');
+});
+
+it('works for streams', async () => {
+  async function* Component() {
+    yield 3;
+    yield 2;
+    yield 1;
+    return 'LIFTOFF';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+
+  const frames = [] as string[];
+  const renderResult = ctx.render(element);
+  for await (const frame of renderResult) {
+    frames.push(frame);
+  }
+  expect(frames).toEqual(['3', '2', '1']);
+  expect(await renderResult).toBe('LIFTOFF');
+  expect(await ctx.render(element)).toBe('LIFTOFF');
+});
+
+it('works for append-only streams', async () => {
+  async function* Component() {
+    yield AI.AppendOnlyStream;
+    yield 3;
+    yield 2;
+    yield 1;
+    return 'LIFTOFF';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+
+  const frames = [] as string[];
+  const renderResult = ctx.render(element);
+  for await (const frame of renderResult) {
+    frames.push(frame);
+  }
+  expect(frames).toEqual(['', '3', '32', '321']);
+  expect(await renderResult).toEqual('321LIFTOFF');
+  expect(await ctx.render(element)).toBe('321LIFTOFF');
+});
+
+it('works for streams that become append-only', async () => {
+  async function* Component() {
+    yield 4;
+    yield 3;
+    yield AI.AppendOnlyStream;
+    yield 2;
+    yield 1;
+    return 'LIFTOFF';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+
+  const frames = [] as string[];
+  const renderResult = ctx.render(element);
+  for await (const frame of renderResult) {
+    frames.push(frame);
+  }
+  expect(frames).toEqual(['4', '3', '3', '32', '321']);
+  expect(await renderResult).toEqual('321LIFTOFF');
+  expect(await ctx.render(element)).toBe('321LIFTOFF');
+});
+
+it('works for streams that become append-only using a value', async () => {
+  async function* Component() {
+    yield 4;
+    yield 3;
+    yield AI.AppendOnlyStream(2);
+    yield 1;
+    return 'LIFTOFF';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+
+  const frames = [] as string[];
+  const renderResult = ctx.render(element);
+  for await (const frame of renderResult) {
+    frames.push(frame);
+  }
+  expect(frames).toEqual(['4', '3', '32', '321']);
+  expect(await renderResult).toEqual('321LIFTOFF');
+  expect(await ctx.render(element)).toBe('321LIFTOFF');
+});
+
+it('coalesces frames when there are multiple concurrent renders', async () => {
+  async function* Component() {
+    yield AI.AppendOnlyStream;
+    yield 3;
+    yield 2;
+    yield 1;
+    return 'LIFTOFF';
+  }
+
+  const ctx = AI.createRenderContext();
+  const element = ctx.memo(<Component />);
+
+  const iterator1 = ctx.render(element)[Symbol.asyncIterator]();
+  const iterator2 = ctx.render(element)[Symbol.asyncIterator]();
+
+  expect((await iterator1.next()).value).toBe('');
+  expect((await iterator2.next()).value).toBe('');
+
+  expect((await iterator1.next()).value).toBe('3');
+  expect((await iterator1.next()).value).toBe('32');
+  expect((await iterator1.next()).value).toBe('321');
+  expect((await iterator2.next()).value).toBe('321');
+
+  expect(await iterator1.next()).toEqual({ value: '321LIFTOFF', done: true });
+  expect(await iterator2.next()).toEqual({ value: '321LIFTOFF', done: true });
+
+  const iterator3 = ctx.render(element)[Symbol.asyncIterator]();
+  expect(await iterator3.next()).toEqual({ value: '321LIFTOFF', done: true });
+});


### PR DESCRIPTION
- Change the behavior of `memo` so that it only yields the most recently rendered frame, rather than replaying the entire stream. When combined with non-append-only streams + partial rendering the previous behavior could cause an exponential blowup in the number of frames.
- Change `AI.AppendOnlyStream` to be a function that takes a `Node` so that converting a stream to append-only does not require an extra yield (i.e. an extra frame).
- Change partial rendering to memoize returned elements, instead of simply binding the context, and remove the now-unneeded `memo`s in `conversation.tsx` accordingly.
- Source the memoized ID from the render context so that it (can be) deterministic within a single `RenderContext`
- Add unit tests for `memoize.tsx`.