### PR TITLE
Add support for deployment environment variables

### DIFF
--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -36,7 +36,7 @@ async function serve({
 
   const fixieApiUrl = process.env.FIXIE_API_URL ?? 'https://app.fixie.ai';
 
-  const getJwks = createRemoteJWKSet(new URL(`${fixieApiUrl}/.well-known/jwks.json`));
+  const getJwks = createRemoteJWKSet(new URL('/.well-known/jwks.json', fixieApiUrl));
 
   app.addHook('onRequest', async (request, reply) => {
     try {

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/fixie",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -4,7 +4,7 @@
  * This is a command-line tool to interact with the Fixie platform.
  */
 
-import { program } from 'commander';
+import { Command, program } from 'commander';
 import terminal from 'terminal-kit';
 import { FixieClient } from './client.js';
 import { FixieAgent } from './agent.js';
@@ -24,9 +24,29 @@ function showResult(result: any, raw: boolean) {
 }
 
 /** Deploy an agent from the current directory. */
-async function deployAgent(path?: string) {
-  const client = await FixieClient.Create(program.opts().url);
-  await FixieAgent.DeployAgent(client, path ?? process.cwd());
+function registerDeployCommand(command: Command) {
+  command
+    .command('deploy [path]')
+    .description('Deploy an agent')
+    .option(
+      '-e, --env <key=value>',
+      'Environment variables to set',
+      (v, m) => {
+        const [key, value] = v.split('=');
+        return {
+          ...m,
+          [key]: value ?? '',
+        };
+      },
+      {} as Record<string, string>
+    )
+    .action(async (path: string | undefined, options: { env: Record<string, string> }) => {
+      const client = await FixieClient.Create(program.opts().url);
+      await FixieAgent.DeployAgent(client, path ?? process.cwd(), {
+        FIXIE_API_URL: program.opts().url,
+        ...options.env,
+      });
+    });
 }
 
 // Get current version of this package.
@@ -50,12 +70,7 @@ program
     showResult(result, program.opts().raw);
   });
 
-program
-  .command('deploy [path]')
-  .description('Deploy an agent')
-  .action(async (path: string) => {
-    await deployAgent(path);
-  });
+registerDeployCommand(program);
 
 const corpus = program.command('corpus').description('Corpus related commands');
 
@@ -212,12 +227,7 @@ agents
     showResult(result.metadata, program.opts().raw);
   });
 
-agents
-  .command('deploy [path]')
-  .description('Deploy an agent')
-  .action(async (path: string) => {
-    await deployAgent(path);
-  });
+registerDeployCommand(agents);
 
 const revisions = agents.command('revisions').description('Agent revision-related commands');
 


### PR DESCRIPTION
- In `@fixieai/fixie` add a `-e` to option to set deployment environment variables, and set `FIXIE_API_URL` to the instance being invoked.
- In `@fixieai/sdk` use `new URL` to construct the correct JWKS URL.

This obviates the need to create a `.env` file to point at non-prod instances.