### PR TITLE
[@fixieai/sdk] Propagate errors back to service

### DIFF
--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -43,7 +43,6 @@ async function serve({
       const token = request.headers.authorization?.split(' ')[1];
       if (typeof token !== 'string') {
         throw new Error('Missing Authorization header');
-        return;
       }
       (request as any).fixieAuthToken = token;
       (request as any).fixieVerifiedToken = await jwtVerify(token, getJwks);
@@ -76,16 +75,21 @@ async function serve({
         .send(
           Readable.from(
             (async function* () {
+              let lastMessages = [];
               while (true) {
                 try {
                   const next = await generator.next();
-                  const messages = next.value.split('\n').slice(0, -1);
-                  yield `${JSON.stringify({ messages: messages.map((msg) => JSON.parse(msg)) })}\n`;
+                  lastMessages = next.value
+                    .split('\n')
+                    .slice(0, -1)
+                    .map((msg) => JSON.parse(msg));
+                  yield `${JSON.stringify({ messages: lastMessages, state: next.done ? 'done' : 'in-progress' })}\n`;
                   if (next.done) {
                     break;
                   }
                 } catch (ex) {
-                  console.error(`Error during generation: ${ex}${ex instanceof Error ? ` ${ex.stack}` : ''}`);
+                  const errorDetail = `Error during generation: ${ex}${ex instanceof Error ? ` ${ex.stack}` : ''}`;
+                  yield `${JSON.stringify({ messages: lastMessages, errorDetail, state: 'error' })}\n`;
                   break;
                 }
               }

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -90,6 +90,7 @@ async function serve({
                 } catch (ex) {
                   const errorDetail = `Error during generation: ${ex}${ex instanceof Error ? ` ${ex.stack}` : ''}`;
                   yield `${JSON.stringify({ messages: lastMessages, errorDetail, state: 'error' })}\n`;
+                  await generator.return?.();
                   break;
                 }
               }

--- a/packages/fixie-sdk/src/types.ts
+++ b/packages/fixie-sdk/src/types.ts
@@ -48,6 +48,7 @@ export interface InvokeAgentRequest {
 export interface InvokeAgentResponse {
   messages: Message[];
   metadata?: Record<string, string | number | boolean | object | null> | null;
+  errorDetail: string | null;
 }
 
 export interface GetConversationResponse {


### PR DESCRIPTION
This changes the exception handler to propagate the error back to the service via the turn state (note that we've already emitted HTTP 200 by the time we get here).