### PR TITLE
Add support for token-less FixieCorpus tool

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -45,6 +45,15 @@
         "default": "./dist/cjs/batteries/sidekick/platform/sidekick.cjs"
       }
     },
+    "./batteries/fixie": {
+      "import": {
+        "types": "./dist/esm/batteries/fixie.d.ts",
+        "default": "./dist/esm/batteries/fixie.js"
+      },
+      "require": {
+        "default": "./dist/cjs/batteries/fixie.cjs"
+      }
+    },
     "./batteries/docs": {
       "import": {
         "types": "./dist/esm/batteries/docs.d.ts",

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -18,6 +18,8 @@ import * as AI from '../index.js';
 import { Node } from '../index.js';
 import { getEnvVar } from '../lib/util.js';
 import { JsonChatCompletion } from './constrained-output.js';
+import { DEFAULT_API_CONFIGURATION, FixieAPIConfiguration, FixieAPIContext } from './fixie.js';
+import { Tool } from './use-tools.js';
 
 /**
  * A raw document loaded from an arbitrary source that has not yet been parsed.
@@ -616,31 +618,29 @@ export class LocalCorpus<
 
 /** A fully mananged {@link Corpus} served by Fixie. */
 export class FixieCorpus<ChunkMetadata extends Jsonifiable = Jsonifiable> implements Corpus<ChunkMetadata> {
-  private static readonly DEFAULT_FIXIE_API_URL = 'https://beta.fixie.ai';
+  private readonly fixieApiConfiguration: FixieAPIConfiguration;
 
-  private readonly fixieApiUrl: string;
-
-  constructor(private readonly corpusId: string, private readonly fixieApiKey?: string) {
-    if (!fixieApiKey) {
-      this.fixieApiKey = getEnvVar('FIXIE_API_KEY', false);
-      if (!this.fixieApiKey) {
-        throw new AIJSXError(
-          'You must provide a Fixie API key to access Fixie corpora. Find yours at https://beta.fixie.ai/profile.',
-          ErrorCode.MissingFixieAPIKey,
-          'user'
-        );
-      }
+  constructor(
+    private readonly corpusId: string,
+    fixieApiConfiguration: FixieAPIConfiguration = DEFAULT_API_CONFIGURATION
+  ) {
+    this.fixieApiConfiguration = fixieApiConfiguration;
+    if (!this.fixieApiConfiguration.authToken) {
+      throw new AIJSXError(
+        `You must provide a Fixie API key to access Fixie corpora. Find yours at ${this.fixieApiConfiguration.url}/profile.`,
+        ErrorCode.MissingFixieAPIKey,
+        'user'
+      );
     }
-    this.fixieApiUrl = getEnvVar('FIXIE_API_URL', false) ?? FixieCorpus.DEFAULT_FIXIE_API_URL;
   }
 
   async search(query: string, params?: { limit?: number }): Promise<ScoredChunk<ChunkMetadata>[]> {
-    const url = `${this.fixieApiUrl}/api/v1/corpora/${this.corpusId}:query`;
+    const url = new URL(`/api/v1/corpora/${this.corpusId}:query`, this.fixieApiConfiguration.url);
     const response = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.fixieApiKey}`,
+        Authorization: `Bearer ${this.fixieApiConfiguration.authToken}`,
       },
       body: JSON.stringify({
         corpus_id: this.corpusId,
@@ -662,6 +662,36 @@ export class FixieCorpus<ChunkMetadata extends Jsonifiable = Jsonifiable> implem
       },
       score: result.score,
     }));
+  }
+
+  static createTool(corpusId: string, description: string): Tool {
+    return {
+      description,
+      parameters: {
+        query: {
+          description: 'The search query. It will be embedded and used in a vector search against the corpus.',
+          type: 'string',
+          required: true,
+        },
+      },
+      func: async function FixieCorpusQuery({ query }: { query: string }, { getContext }) {
+        const corpus = new FixieCorpus(corpusId, getContext(FixieAPIContext));
+
+        const results = await corpus.search(query);
+
+        /**
+         * Reverse the array so the closest chunk is listed last.
+         *
+         * N.B.: The results will not be sorted by `score` because the Fixie API reranks the chunks.
+         */
+        results.reverse();
+
+        return JSON.stringify({
+          kind: 'docs',
+          results: _.uniqBy(results, (result) => result.chunk.content),
+        });
+      },
+    };
   }
 }
 

--- a/packages/ai-jsx/src/batteries/fixie.tsx
+++ b/packages/ai-jsx/src/batteries/fixie.tsx
@@ -1,0 +1,14 @@
+import { createContext } from '../core/render.js';
+import { getEnvVar } from '../lib/util.js';
+
+export interface FixieAPIConfiguration {
+  url: string;
+  authToken?: string;
+}
+
+export const DEFAULT_API_CONFIGURATION: FixieAPIConfiguration = {
+  url: getEnvVar('FIXIE_API_URL', false) ?? 'https://app.fixie.ai',
+  authToken: getEnvVar('FIXIE_API_KEY', false),
+};
+
+export const FixieAPIContext = createContext<FixieAPIConfiguration>(DEFAULT_API_CONFIGURATION);

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -12,7 +12,7 @@ import {
   renderToConversation,
   SystemMessage,
 } from '../../../core/conversation.js';
-import { UseToolsProps } from '../../use-tools.js';
+import { ExecuteFunction, UseToolsProps } from '../../use-tools.js';
 
 /**
  * This function defines the shrinking policy. It's activated when the conversation history overflows the context
@@ -73,7 +73,7 @@ export function present(conversationElement: ConversationMessage) {
  * without using tools. For example, this is how the model is able to call `listConversations`, followed by
  * `getConversation`, and then finally write a response.
  */
-export async function getNextConversationStep(
+export function getNextConversationStep(
   messages: ConversationMessage[],
   fullConversation: ConversationMessage[],
   finalSystemMessageBeforeResponse: AI.Node,
@@ -84,15 +84,7 @@ export async function getNextConversationStep(
   switch (lastMessage.type) {
     case 'functionCall': {
       const { name, args } = lastMessage.element.props;
-      try {
-        return <FunctionResponse name={name}>{await tools[name].func(args)}</FunctionResponse>;
-      } catch (e: any) {
-        return (
-          <FunctionResponse failed name={name}>
-            {e.message}
-          </FunctionResponse>
-        );
-      }
+      return <ExecuteFunction func={tools[name].func} name={name} args={args} />;
     }
     case 'functionResponse':
       return (

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -1,7 +1,6 @@
 import { present } from './conversation.js';
 import { UseTools } from './use-tools-eject.js';
 import { SidekickSystemMessage } from './system-message.js';
-import _ from 'lodash';
 import { OpenAI } from '../../../lib/openai.js';
 import { UseToolsProps } from '../../use-tools.js';
 import * as AI from '../../../index.js';
@@ -52,31 +51,12 @@ export interface SidekickProps {
   role: string;
 }
 
-function makeObservedTools(tools: UseToolsProps['tools'], logger: AI.ComponentContext['logger']) {
-  return _.mapValues(tools, (tool, toolName) => ({
-    ...tool,
-    func: async (...args: Parameters<typeof tool.func>) => {
-      logger.info({ toolName, args }, 'Calling tool');
-      try {
-        const result = await Promise.resolve(tool.func(...args));
-        logger.info({ toolName, args, result }, 'Got result from tool');
-        return typeof result === 'string' ? result : JSON.stringify(result);
-      } catch (e) {
-        logger.error({ toolName, args, e }, 'Got error calling tool');
-        throw e;
-      }
-    },
-  }));
-}
-
-export function Sidekick(props: SidekickProps, { logger }: AI.ComponentContext) {
-  const observedTools = makeObservedTools(props.tools ?? {}, logger);
-
+export function Sidekick(props: SidekickProps) {
   return (
     <ModelProvider model="gpt-4-32k" modelProvider="openai">
       <ShowConversation present={present}>
         <UseTools
-          tools={observedTools}
+          tools={props.tools ?? {}}
           showSteps
           finalSystemMessageBeforeResponse={props.finalSystemMessageBeforeResponse}
         >

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -23,7 +23,13 @@ export interface Tool {
   parameters: FunctionParameters;
 
   /**
-   * A function/component that invokes the tool.
+   * A function that invokes the tool.
+   *
+   * @remarks
+   * The function will be treated as an AI.JSX component: the tool parameters
+   * will be passed as fields on the first argument (props) and the function
+   * can return a `string` or any AI.JSX {@link Node}, synchronously or
+   * asynchronously.
    */
   // Can we use Zod to do better than any?
   func: Component<any>;

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.16.0
+## 0.17.0
+
+- Changed `<UseTools>` to allow AI.JSX components to be tools.
+- Added `FixieAPIConfiguration` context.
+- Changed `FixieCorpus` to take a `FixieAPIConfiguration`.
+- Added the `FixieCorpus.createTool` helper to create a tool that consults a Fixie corpus.
+
+## [0.16.0](https://github.com/fixie-ai/ai-jsx/commit/c951b4695c97230016b1ae2763649f67089adf92)
 
 - Updated default URL for `<FixieCorpus>` to `api.fixie.ai`.
 

--- a/packages/examples/test/batteries/use-tools.tsx
+++ b/packages/examples/test/batteries/use-tools.tsx
@@ -1,0 +1,124 @@
+import * as AI from 'ai-jsx';
+import { UseTools } from 'ai-jsx/batteries/use-tools';
+import { ChatProvider } from 'ai-jsx/core/completion';
+import {
+  AssistantMessage,
+  FunctionCall,
+  ShowConversation,
+  UserMessage,
+  renderToConversation,
+} from 'ai-jsx/core/conversation';
+
+async function FakeChatCompletion({ children }: { children: AI.Node }, { render }: AI.ComponentContext) {
+  const nodes = await renderToConversation(children, render);
+  if (nodes.find((n) => n.type === 'functionCall')) {
+    return <AssistantMessage>DONE</AssistantMessage>;
+  }
+  return <FunctionCall name="myFunc" args={{ parameter: 'test parameter value' }} />;
+}
+
+describe('useTools', () => {
+  it('should give tools access to context', async () => {
+    const myContext = AI.createContext(0);
+
+    function MyTool({ parameter }: { parameter: string }, { getContext }: AI.ComponentContext) {
+      return (
+        <>
+          {parameter}: {getContext(myContext)}
+        </>
+      );
+    }
+
+    const renderCtx = AI.createRenderContext();
+    const result = await renderCtx.render(
+      <ShowConversation
+        present={(m) => (
+          <>
+            {m.type}: {m.element}
+            {'\n'}
+          </>
+        )}
+      >
+        <myContext.Provider value={42}>
+          <ChatProvider component={FakeChatCompletion}>
+            <UseTools
+              showSteps
+              tools={{
+                myFunc: {
+                  description: 'Test tool',
+                  parameters: {
+                    parameter: {
+                      description: 'Test parameter',
+                      type: 'string',
+                      required: true,
+                    },
+                  },
+                  func: MyTool,
+                },
+              }}
+            >
+              <UserMessage>Hello!</UserMessage>
+            </UseTools>
+          </ChatProvider>
+        </myContext.Provider>
+      </ShowConversation>
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "functionCall: Call function myFunc with {"parameter":"test parameter value"}
+      functionResponse: function myFunc returned test parameter value: 42
+      assistant: DONE
+      "
+    `);
+  });
+
+  it('should handle failures', async () => {
+    const myContext = AI.createContext(0);
+
+    function MyTool(_: { parameter: string }): AI.Node {
+      throw new Error('ERROR!');
+    }
+
+    const renderCtx = AI.createRenderContext();
+    const result = await renderCtx.render(
+      <ShowConversation
+        present={(m) => (
+          <>
+            {m.type}: {m.element}
+            {'\n'}
+          </>
+        )}
+      >
+        <myContext.Provider value={42}>
+          <ChatProvider component={FakeChatCompletion}>
+            <UseTools
+              showSteps
+              tools={{
+                myFunc: {
+                  description: 'Test tool',
+                  parameters: {
+                    parameter: {
+                      description: 'Test parameter',
+                      type: 'string',
+                      required: true,
+                    },
+                  },
+                  func: MyTool,
+                },
+              }}
+            >
+              <UserMessage>Hello!</UserMessage>
+            </UseTools>
+          </ChatProvider>
+        </myContext.Provider>
+      </ShowConversation>
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "functionCall: Call function myFunc with {"parameter":"test parameter value"}
+      functionResponse: function myFunc failed with Error: ERROR!
+      assistant: DONE
+      "
+    `);
+  });
+});

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
@@ -21,7 +21,7 @@
     "fixie-serve-bin": "dist/fixie-serve-bin.js"
   },
   "peerDependencies": {
-    "ai-jsx": ">=0.12.0 <1.0.0"
+    "ai-jsx": ">=0.16.0 <1.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.4.1",

--- a/packages/fixie-sdk/src/conversation.tsx
+++ b/packages/fixie-sdk/src/conversation.tsx
@@ -2,10 +2,12 @@
 import * as AI from 'ai-jsx';
 import { GetConversationResponse } from './types.js';
 import { AssistantMessage, FunctionCall, FunctionResponse, UserMessage } from 'ai-jsx/core/conversation';
-import { fixieContext } from './request-wrapper.js';
+import { RequestContext } from './request-wrapper.js';
+import { FixieAPIContext } from 'ai-jsx/batteries/fixie';
 
 export async function FixieConversation(_: {}, { getContext }: AI.ComponentContext) {
-  const fixieContextValue = getContext(fixieContext);
+  const fixieApiContextValue = getContext(FixieAPIContext);
+  const fixieContextValue = getContext(RequestContext);
   if (!fixieContextValue) {
     throw new Error('FixieConversation components may only be used in the context of requests from Fixie.');
   }
@@ -13,9 +15,9 @@ export async function FixieConversation(_: {}, { getContext }: AI.ComponentConte
   const response = await fetch(
     new URL(
       `/api/v1/agents/${fixieContextValue.agentId}/conversations/${fixieContextValue.request.conversationId}`,
-      fixieContextValue.apiBaseUrl
+      fixieApiContextValue.url
     ),
-    { headers: { Authorization: `Bearer ${fixieContextValue.authToken}` } }
+    { headers: { Authorization: `Bearer ${fixieApiContextValue.authToken}` } }
   );
 
   const json: GetConversationResponse = await response.json();

--- a/packages/fixie-sdk/src/request-wrapper.tsx
+++ b/packages/fixie-sdk/src/request-wrapper.tsx
@@ -4,30 +4,19 @@ import { ShowConversation, ConversationHistoryContext } from 'ai-jsx/core/conver
 import { Json } from './json.js';
 import { FixieConversation } from './conversation.js';
 import { OpenAI, OpenAIClient, ValidChatModel } from 'ai-jsx/lib/openai';
+import { FixieAPIContext } from 'ai-jsx/batteries/fixie';
 
-export interface FixieRequestContext {
+export const RequestContext = AI.createContext<{
   request: InvokeAgentRequest;
   agentId: string;
-  apiBaseUrl: string;
-  authToken: string;
-}
-
-export const fixieContext = AI.createContext<FixieRequestContext | null>(null);
+} | null>(null);
 
 /**
  * Wraps a conversational AI.JSX component to be used as a Fixie request handler.
  *
  * Emits newline-delimited JSON for each message.
  */
-export function FixieRequestWrapper({
-  request,
-  agentId,
-  apiBaseUrl,
-  authToken,
-  children,
-}: FixieRequestContext & {
-  children: AI.Node;
-}) {
+export function FixieRequestWrapper({ children }: { children: AI.Node }, { getContext, memo }: AI.ComponentContext) {
   let wrappedNode: AI.Node = (
     <ShowConversation
       present={(message) => {
@@ -74,6 +63,14 @@ export function FixieRequestWrapper({
     </ShowConversation>
   );
 
+  const { url: apiBaseUrl, authToken } = getContext(FixieAPIContext);
+
+  const requestContext = getContext(RequestContext);
+  if (!requestContext) {
+    throw new Error('RequestContext must be provided to FixieRequestWrapper.');
+  }
+  const { request } = requestContext;
+
   // If we're using OpenAI (or default), enable the OpenAI proxy.
   if (!request.generationParams.modelProvider || request.generationParams.modelProvider.toLowerCase() === 'openai') {
     wrappedNode = (
@@ -95,10 +92,8 @@ export function FixieRequestWrapper({
   }
 
   return (
-    <fixieContext.Provider value={{ request, agentId, authToken, apiBaseUrl }}>
-      <ConversationHistoryContext.Provider value={<FixieConversation />}>
-        {wrappedNode}
-      </ConversationHistoryContext.Provider>
-    </fixieContext.Provider>
+    <ConversationHistoryContext.Provider value={memo(<FixieConversation />)}>
+      {wrappedNode}
+    </ConversationHistoryContext.Provider>
   );
 }

--- a/packages/sidekick-github/src/index.tsx
+++ b/packages/sidekick-github/src/index.tsx
@@ -28,7 +28,7 @@ const tools: Record<string, Tool> = {
       if (!response.ok) {
         throw new Error(`GH request failed: ${response.status} ${response.statusText} ${response.body}`);
       }
-      return response.json();
+      return response.text();
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,7 +3113,7 @@ __metadata:
     typescript: ^5.1.3
     yargs: ^17.7.2
   peerDependencies:
-    ai-jsx: ">=0.12.0 <1.0.0"
+    ai-jsx: ">=0.16.0 <1.0.0"
   bin:
     fixie-serve-bin: dist/fixie-serve-bin.js
   languageName: unknown


### PR DESCRIPTION
This change:
- Changes tools to be `Component<any>` (which is compatible with the existing signature) so they can access context and/or return other AI.JSX nodes
- Adds an `<ExecuteFunction>` component that encapsulates error handling so it can be shared between the two `UseTools` implementations
- Adds `FixieAPIContext` to AI.JSX where the Fixie API url/token can be configured
- Adds `FixieCorpus.createTool` which facilitates `FixieCorpus`-based `Tool` creation and reads the API configuration from context (rather than from `process.env`).