### PR TITLE
Fix incorrect JSON-serialization

### DIFF
--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -77,9 +77,11 @@ async function serve({
             (async function* () {
               let lastMessages = [];
               while (true) {
+                let currentValue = undefined as string | undefined;
                 try {
                   const next = await generator.next();
-                  lastMessages = next.value
+                  currentValue = next.value;
+                  lastMessages = currentValue
                     .split('\n')
                     .slice(0, -1)
                     .map((msg) => JSON.parse(msg));
@@ -89,6 +91,7 @@ async function serve({
                   }
                 } catch (ex) {
                   const errorDetail = `Error during generation: ${ex}${ex instanceof Error ? ` ${ex.stack}` : ''}`;
+                  console.error({ currentValue, errorDetail });
                   yield `${JSON.stringify({ messages: lastMessages, errorDetail, state: 'error' })}\n`;
                   await generator.return?.();
                   break;


### PR DESCRIPTION
In the JSON serializer in `@fixieai/sdk`:
- `undefined` fields should be elided entirely
- `undefined` values in arrays should be replaced with `null`
- `null` values should be serialized as `null`