### PR TITLE
Update createCorpus API to take a `description` argument

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/fixie",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -11,6 +11,7 @@
     "start": "node --no-warnings dist/src/main.js",
     "build-start": "yarn run build && yarn run start",
     "format": "prettier --write .",
+    "test": "yarn run build && yarn run lint",
     "lint": "eslint .",
     "lint:fix": "eslint ."
   },

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -476,7 +476,7 @@ export class FixieAgent {
     }
 
     // Start the agent process locally.
-    const agentProcess = FixieAgent.spawnAgentProcess(agentPath, port);
+    FixieAgent.spawnAgentProcess(agentPath, port);
 
     // Wait for 5 seconds for it to start up.
     await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -95,7 +95,7 @@ export class IsomorphicFixieClient {
     const body = {
       corpus: {
         display_name: name,
-        description
+        description,
       },
     };
     return this.request('/api/v1/corpora', body);

--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -91,10 +91,11 @@ export class IsomorphicFixieClient {
   }
 
   /** Create a new Corpus. */
-  createCorpus(name?: string): Promise<Jsonifiable> {
+  createCorpus(name?: string, description?: string): Promise<Jsonifiable> {
     const body = {
       corpus: {
         display_name: name,
+        description
       },
     };
     return this.request('/api/v1/corpora', body);

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -129,11 +129,11 @@ corpus
   });
 
 corpus
-  .command('create [corpusName]')
+  .command('create [name] [description]')
   .description('Create a corpus.')
-  .action(async (corpusName?: string) => {
+  .action(async (name?: string, description?: string) => {
     const client = await FixieClient.Create(program.opts().url);
-    const result = await client.createCorpus(corpusName);
+    const result = await client.createCorpus(name, description);
     showResult(result, program.opts().raw);
   });
 


### PR DESCRIPTION
Demo: 
```
yarn workspace @fixieai/fixie start corpus create nick-test-4 my-description
{
  "corpus": {
    "corpusId": "99371933-4e30-4f63-b1a2-a0b0b72e699f",
    "displayName": "nick-test-4",
    "created": "2023-09-13T14:55:33.574951Z",
    "modified": "2023-09-13T14:55:33.605644Z",
    "stats": {
      "status": "CORPUS_STATUS_EMPTY"
    },
    "description": "my-description"
  }
}⏎                                                                                                                                                                                                                
```