### PR TITLE
Allow --include-patterns and --exclude-patterns to be specified on the command line.

### DIFF
--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -125,6 +125,8 @@ export class IsomorphicFixieClient {
   addCorpusSource(
     corpusId: string,
     startUrls: string[],
+    includeGlobs?: string[],
+    excludeGlobs?: string[],
     maxDocuments?: number,
     maxDepth?: number
   ): Promise<Jsonifiable> {
@@ -137,11 +139,12 @@ export class IsomorphicFixieClient {
           web: {
             start_urls: startUrls,
             max_depth: maxDepth,
+            include_glob_patterns: includeGlobs,
+            exclude_glob_patterns: excludeGlobs,
           },
         },
       },
     };
-
     return this.request(`/api/v1/corpora/${corpusId}/sources`, body);
   }
 

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -179,14 +179,36 @@ sources
   .description('Add a source to a corpus.')
   .option('--max-documents <number>', 'Maximum number of documents to crawl')
   .option('--max-depth <number>', 'Maximum depth to crawl')
+  .option('--include-patterns <pattern...>', 'URL patterns to include in the crawl')
+  .option('--exclude-patterns <pattern...>', 'URL patterns to exclude from the crawl')
   .action(
     async (
       corpusId: string,
       startUrls: string[],
-      { maxDocuments, maxDepth }: { maxDocuments?: number; maxDepth?: number }
+      {
+        maxDocuments,
+        maxDepth,
+        includePatterns,
+        excludePatterns,
+      }: { maxDocuments?: number; maxDepth?: number; includePatterns?: string[]; excludePatterns: string[] }
     ) => {
+      if (!includePatterns) {
+        term.yellow('Warning: ')(
+          'No --include-patterns specfied. This is equivalent to only crawling the URLs specified as startUrls.\n'
+        );
+        term.yellow('Warning: ')('Use ').red("--include-patterns '*'")(
+          ' if you want to allow all URLs in the crawl.\n'
+        );
+      }
       const client = await AuthenticateOrLogIn({ apiUrl: program.opts().url });
-      const result = await client.addCorpusSource(corpusId, startUrls, maxDocuments, maxDepth);
+      const result = await client.addCorpusSource(
+        corpusId,
+        startUrls,
+        includePatterns,
+        excludePatterns,
+        maxDocuments,
+        maxDepth
+      );
       showResult(result, program.opts().raw);
     }
   );

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -190,7 +190,7 @@ sources
         maxDepth,
         includePatterns,
         excludePatterns,
-      }: { maxDocuments?: number; maxDepth?: number; includePatterns?: string[]; excludePatterns: string[] }
+      }: { maxDocuments?: number; maxDepth?: number; includePatterns?: string[]; excludePatterns?: string[] }
     ) => {
       if (!includePatterns) {
         term.yellow('Warning: ')(


### PR DESCRIPTION
With #1683 landing on fixie-ai/fixie, it is now required that the client specify include_glob_patterns and exclude_glob_patterns when creating a source. This PR adds this as a flag to the CLI.

@NickHeiner You will want to make a similar change to the UI I expect.
