### PR TITLE
Use the singular consistently

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -135,6 +135,7 @@ config
   });
 
 const corpus = program.command('corpus').description('Corpus related commands');
+corpus.alias('corpora');
 
 corpus
   .command('list')
@@ -173,6 +174,7 @@ corpus
   });
 
 const source = corpus.command('source').description('Corpus source related commands');
+source.alias('sources');
 
 source
   .command('add <corpusId> <startUrls...>')
@@ -219,6 +221,7 @@ source
   });
 
 const job = source.command('job').description('Job-related commands');
+job.alias('jobs');
 
 job
   .command('list <corpusId> <sourceId>')
@@ -238,9 +241,10 @@ job
     showResult(result, program.opts().raw);
   });
 
-const docs = corpus.command('docs').description('Document-related commands');
+const doc = corpus.command('doc').description('Document-related commands');
+doc.alias('docs');
 
-docs
+doc
   .command('list <corpusId>')
   .description('List documents for a given corpus.')
   .action(async (corpusId: string) => {
@@ -249,7 +253,7 @@ docs
     showResult(result, program.opts().raw);
   });
 
-job
+doc
   .command('get <corpusId> <docId>')
   .description('Get a document for a corpus.')
   .action(async (corpusId: string, docId: string) => {
@@ -259,6 +263,7 @@ job
   });
 
 const agent = program.command('agent').description('Agent related commands');
+agent.alias('agents');
 
 agent
   .command('list')
@@ -321,6 +326,7 @@ registerDeployCommand(agent);
 registerServeCommand(agent);
 
 const revision = agent.command('revision').description('Agent revision-related commands');
+revision.alias('revisions');
 
 revision
   .command('list <agentId>')

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -172,9 +172,9 @@ corpus
     showResult(result, program.opts().raw);
   });
 
-const sources = corpus.command('sources').description('Corpus source related commands');
+const source = corpus.command('source').description('Corpus source related commands');
 
-sources
+source
   .command('add <corpusId> <startUrls...>')
   .description('Add a source to a corpus.')
   .option('--max-documents <number>', 'Maximum number of documents to crawl')
@@ -191,7 +191,7 @@ sources
     }
   );
 
-sources
+source
   .command('list <corpusId>')
   .description('List sources of a corpus.')
   .action(async (corpusId: string) => {
@@ -200,7 +200,7 @@ sources
     showResult(result, program.opts().raw);
   });
 
-sources
+source
   .command('get <corpusId> <sourceId>')
   .description('Get a source for a corpus.')
   .action(async (corpusId: string, sourceId: string) => {
@@ -209,7 +209,7 @@ sources
     showResult(result, program.opts().raw);
   });
 
-sources
+source
   .command('refresh <corpusId> <sourceId>')
   .description('Refresh a corpus source.')
   .action(async (corpusId: string, sourceId: string) => {
@@ -218,9 +218,9 @@ sources
     showResult(result, program.opts().raw);
   });
 
-const jobs = sources.command('jobs').description('Job-related commands');
+const job = source.command('job').description('Job-related commands');
 
-jobs
+job
   .command('list <corpusId> <sourceId>')
   .description('List jobs for a given source.')
   .action(async (corpusId: string, sourceId: string) => {
@@ -229,7 +229,7 @@ jobs
     showResult(result, program.opts().raw);
   });
 
-jobs
+job
   .command('get <corpusId> <sourceId> <jobId>')
   .description('Get a job for a source.')
   .action(async (corpusId: string, sourceId: string, jobId: string) => {
@@ -249,7 +249,7 @@ docs
     showResult(result, program.opts().raw);
   });
 
-jobs
+job
   .command('get <corpusId> <docId>')
   .description('Get a document for a corpus.')
   .action(async (corpusId: string, docId: string) => {
@@ -258,9 +258,9 @@ jobs
     showResult(result, program.opts().raw);
   });
 
-const agents = program.command('agents').description('Agent related commands');
+const agent = program.command('agent').description('Agent related commands');
 
-agents
+agent
   .command('list')
   .description('List all agents.')
   .action(async () => {
@@ -269,7 +269,7 @@ agents
     showResult(await Promise.all(result.map((agent) => agent.agentId)), program.opts().raw);
   });
 
-agents
+agent
   .command('get <agentId>')
   .description('Get information about the given agent.')
   .action(async (agentId: string) => {
@@ -278,7 +278,7 @@ agents
     showResult(result.metadata, program.opts().raw);
   });
 
-agents
+agent
   .command('delete <agentHandle>')
   .description('Delete the given agent.')
   .action(async (agentHandle: string) => {
@@ -288,7 +288,7 @@ agents
     showResult(result, program.opts().raw);
   });
 
-agents
+agent
   .command('publish <agentId>')
   .description('Publish the given agent.')
   .action(async (agentHandle: string) => {
@@ -298,7 +298,7 @@ agents
     showResult(result, program.opts().raw);
   });
 
-agents
+agent
   .command('unpublish <agentId>')
   .description('Unpublish the given agent.')
   .action(async (agentHandle: string) => {
@@ -308,7 +308,7 @@ agents
     showResult(result, program.opts().raw);
   });
 
-agents
+agent
   .command('create <agentHandle> [agentName] [agentDescription] [agentMoreInfoUrl]')
   .description('Create an agent.')
   .action(async (agentHandle: string, agentName?: string, agentDescription?: string, agentMoreInfoUrl?: string) => {
@@ -317,12 +317,12 @@ agents
     showResult(result.metadata, program.opts().raw);
   });
 
-registerDeployCommand(agents);
-registerServeCommand(agents);
+registerDeployCommand(agent);
+registerServeCommand(agent);
 
-const revisions = agents.command('revisions').description('Agent revision-related commands');
+const revision = agent.command('revision').description('Agent revision-related commands');
 
-revisions
+revision
   .command('list <agentId>')
   .description('List all revisions for the given agent.')
   .action(async (agentId: string) => {
@@ -331,7 +331,7 @@ revisions
     showResult(result, program.opts().raw);
   });
 
-revisions
+revision
   .command('get <agentId>')
   .description('Get current revision for the given agent.')
   .action(async (agentId: string) => {
@@ -341,7 +341,7 @@ revisions
     showResult(result, program.opts().raw);
   });
 
-revisions
+revision
   .command('set <agentId> <revisionId>')
   .description('Set the current revision for the given agent.')
   .action(async (agentId: string, revisionId: string) => {
@@ -351,7 +351,7 @@ revisions
     showResult(result, program.opts().raw);
   });
 
-revisions
+revision
   .command('delete <agentId> <revisionId>')
   .description('Delete the given revision for the given agent.')
   .action(async (agentId: string, revisionId: string) => {


### PR DESCRIPTION
If we have `fixie corpus list`, we should also support `fixie agent list` rather than `fixie agents list`