### PR TITLE
Add `corpus source upload` command to upload files to a Corpus.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/client.ts
+++ b/packages/fixie/src/client.ts
@@ -1,10 +1,9 @@
-import fs from 'fs';
 import { ApolloClient } from '@apollo/client/core/ApolloClient.js';
 import { InMemoryCache } from '@apollo/client/cache/inmemory/inMemoryCache.js';
 import createUploadLink from 'apollo-upload-client/public/createUploadLink.js';
 import isExtractableFile from 'apollo-upload-client/public/isExtractableFile.js';
 import { ExtractableFile } from 'extract-files';
-import { ReadStream } from 'fs';
+import fs, { ReadStream } from 'fs';
 import { IsomorphicFixieClient } from './isomorphic-client.js';
 import type { Jsonifiable } from 'type-fest';
 

--- a/packages/fixie/src/client.ts
+++ b/packages/fixie/src/client.ts
@@ -66,8 +66,6 @@ export class FixieClient extends IsomorphicFixieClient {
         },
       },
     };
-    console.log('SENDING BODY: ');
-    console.log(JSON.stringify(body));
     return this.request(`/api/v1/corpora/${corpusId}/sources`, body);
   }
 }

--- a/packages/fixie/src/client.ts
+++ b/packages/fixie/src/client.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { ApolloClient } from '@apollo/client/core/ApolloClient.js';
 import { InMemoryCache } from '@apollo/client/cache/inmemory/inMemoryCache.js';
 import createUploadLink from 'apollo-upload-client/public/createUploadLink.js';
@@ -5,6 +6,7 @@ import isExtractableFile from 'apollo-upload-client/public/isExtractableFile.js'
 import { ExtractableFile } from 'extract-files';
 import { ReadStream } from 'fs';
 import { IsomorphicFixieClient } from './isomorphic-client.js';
+import type { Jsonifiable } from 'type-fest';
 
 /**
  * A client to the Fixie AI platform.
@@ -45,5 +47,28 @@ export class FixieClient extends IsomorphicFixieClient {
           isExtractableFile(value) || (typeof ReadStream !== 'undefined' && value instanceof ReadStream),
       }),
     });
+  }
+
+  /** Add a new static file Source to a Corpus. */
+  addFileCorpusSource(corpusId: string, filenames: string[], mimeType: string): Promise<Jsonifiable> {
+    const body = {
+      corpus_id: corpusId,
+      source: {
+        corpus_id: corpusId,
+        load_spec: {
+          max_documents: filenames.length,
+          static: {
+            documents: filenames.map((filename) => ({
+              filename,
+              mime_type: mimeType,
+              contents: Buffer.from(fs.readFileSync(filename, 'utf8')).toString('base64'),
+            })),
+          },
+        },
+      },
+    };
+    console.log('SENDING BODY: ');
+    console.log(JSON.stringify(body));
+    return this.request(`/api/v1/corpora/${corpusId}/sources`, body);
   }
 }

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -178,7 +178,7 @@ source.alias('sources');
 
 source
   .command('add <corpusId> <startUrls...>')
-  .description('Add a source to a corpus.')
+  .description('Add a web source to a corpus.')
   .option('--max-documents <number>', 'Maximum number of documents to crawl')
   .option('--max-depth <number>', 'Maximum depth to crawl')
   .option('--include-patterns <pattern...>', 'URL patterns to include in the crawl')
@@ -214,6 +214,15 @@ source
       showResult(result, program.opts().raw);
     }
   );
+
+source
+  .command('upload <corpusId> <mimeType> <filenames...>')
+  .description('Upload local files to a corpus.')
+  .action(async (corpusId: string, mimeType: string, filenames: string[]) => {
+    const client = await AuthenticateOrLogIn({ apiUrl: program.opts().url });
+    const result = await client.addFileCorpusSource(corpusId, filenames, mimeType);
+    showResult(result, program.opts().raw);
+  });
 
 source
   .command('list <corpusId>')


### PR DESCRIPTION
I am not sure the backend support for this is working as of yet, but at least this will unblock experimentation.