### PR TITLE
Increasing token limit for APIs (Patches #1721)

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -108,7 +108,7 @@ export function getNextConversationStep(
       // Function responses can potentially be very large. In that case, we need
       // some way of handling that so the context window doesn't blow up.
       return (
-        <LargeFunctionResponseWrapper numChunks={4} maxLength={4000} failedMaxLength={2000}>
+        <LargeFunctionResponseWrapper numChunks={10} maxLength={10500} failedMaxLength={4000}>
           {executedFunction}
         </LargeFunctionResponseWrapper>
       );

--- a/packages/ai-jsx/src/batteries/sidekick/platform/large-response-handler.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/large-response-handler.tsx
@@ -205,7 +205,7 @@ export function redactedFunctionTools(messages: ConversationMessage[]): UseTools
         <RerankerFormatted
           query={query}
           documents={responseContent.chunks}
-          top_n={2}
+          top_n={6}
           Formatter={MarkdownChunkFormatter}
         />
       ),


### PR DESCRIPTION
With the current defaults, it's possible that responses from a FixieCorpus search will be snipped. This PR fixes this for now by increasing the token limit. We might need to reconsider these numbers in the future.