### PR TITLE
Fix error when functionDefinitions is empty

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -353,7 +353,7 @@ export async function* OpenAIChatModel(
   }
 
   const openaiFunctions = !props.functionDefinitions
-    ? undefined
+    ? []
     : Object.entries(props.functionDefinitions).map(([functionName, functionDefinition]) => ({
         name: functionName,
         description: functionDefinition.description,
@@ -367,7 +367,7 @@ export async function* OpenAIChatModel(
     temperature: props.temperature,
     top_p: props.topP,
     messages,
-    functions: openaiFunctions,
+    functions: openaiFunctions.length > 0 ? openaiFunctions : undefined,
     function_call: props.forcedFunction ? { name: props.forcedFunction } : undefined,
     stop: props.stop,
     logit_bias: props.logitBias ? logitBiasOfTokens(props.logitBias) : undefined,

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.17.3
+## 0.17.4
+
+- Fixed a bug where passing an empty `functionDefinitions` prop to `<OpenAIChatModel>` would cause an error.
+
+## [0.17.3](https://github.com/fixie-ai/ai-jsx/commit/cd206fc81dc4a22eb66f7d95e40cc826b6fd57f3)
 
 - Added the ability to set Anthropic/OpenAI clients without setting the default model
 


### PR DESCRIPTION
If an empty `functionDefinitions` is passed to `<OpenAIChatModel>` it should be equivalent to passing no definitions.