### PR TITLE
Provide option to omit genUI

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/sidekick/platform/gen-ui.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/gen-ui.tsx
@@ -59,5 +59,5 @@ export function MdxUsageExamples({includeNextStepsRecommendations}: Pick<Sidekic
 
   Example 1: The handlebars template language looks like: \`\{'{'}\{'{'}foo\{'}'}\{'}'}\`
   Example 2: The handlebars template language looks like: `{'{{'}foo{'}}'}`
-</>
+</>;
 }

--- a/packages/ai-jsx/src/batteries/sidekick/platform/gen-ui.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/gen-ui.tsx
@@ -1,5 +1,8 @@
+import { SidekickProps } from './sidekick.js';
+
 // prettier-ignore
-export const mdxUsageExamples = <>
+export function MdxUsageExamples({includeNextStepsRecommendations}: Pick<SidekickProps, 'includeNextStepsRecommendations'>) {
+  return <>
   Respond concisely, using MDX formatting to make your response
   more readable and structured.
 
@@ -29,15 +32,17 @@ export const mdxUsageExamples = <>
   When you show users links to knowledge base, use the {'<Citation />'} component. Its props are:
   {' interface CitationProps { title: string; href: string } '}
 
-  You may suggest follow-up ideas to the user, if they fall within the scope of
-  what you are able to do.
+  {includeNextStepsRecommendations && <>
+    You may suggest follow-up ideas to the user, if they fall within the scope of
+    what you are able to do.
 
-  To give the user a canned reply to respond to you with, use the {'<NextStepsButton />'} component. Here is the interface for its props:
-  {`
-  interface NextStepsButtonProps {
-    prompt: string
-  }
-  `}
+    To give the user a canned reply to respond to you with, use the {'<NextStepsButton />'} component. Here is the interface for its props:
+    {`
+    interface NextStepsButtonProps {
+      prompt: string
+    }
+    `}
+  </>}
 
   When you emit MDX, be sure to use the proper quote type so quote characters in the string do not break the syntax. For instance:
 
@@ -54,4 +59,5 @@ export const mdxUsageExamples = <>
 
   Example 1: The handlebars template language looks like: \`\{'{'}\{'{'}foo\{'}'}\{'}'}\`
   Example 2: The handlebars template language looks like: `{'{{'}foo{'}}'}`
-</>;
+</>
+}

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -56,7 +56,7 @@ type OutputFormatSidekickProps = MergeExclusive<
      * Pass `text/gen-ui`, or omit this field, to get a Gen UI response.
      * To render this, you'll need an MDX compiler that's aware of the Gen UI components.
      */
-    outputFormat?: 'text/gen-ui' | undefined;
+    outputFormat?: 'text/mdx' | undefined;
 
     genUIExamples?: AI.Node;
     genUIComponentNames?: string[];
@@ -86,7 +86,7 @@ export function Sidekick(props: SidekickProps) {
             timeZone="America/Los_Angeles"
             timeZoneOffset="420"
             role={props.role}
-            outputFormat={props.outputFormat ?? 'text/gen-ui'}
+            outputFormat={props.outputFormat ?? 'text/mdx'}
             userProvidedGenUIUsageExamples={props.genUIExamples}
             userProvidedGenUIComponentNames={props.genUIComponentNames}
           />

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -52,12 +52,21 @@ interface UniversalSidekickProps {
 
 type OutputFormatSidekickProps = MergeExclusive<
   {
-    outputFormat: 'text/gen-ui' | undefined;
+    /**
+     * Pass `text/gen-ui`, or omit this field, to get a Gen UI response.
+     * To render this, you'll need an MDX compiler that's aware of the Gen UI components.
+     */
+    outputFormat?: 'text/gen-ui' | undefined;
 
     genUIExamples?: AI.Node;
     genUIComponentNames?: string[];
   },
   {
+    /**
+     * Pass `text/markdown` to get a Markdown response. To render this, you'll need a Markdown compiler.
+     *
+     * Pass `text/plain` to get a plain text response.
+     */
     outputFormat: 'text/markdown' | 'text/plain';
   }
 >;

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -60,6 +60,19 @@ type OutputFormatSidekickProps = MergeExclusive<
 
     genUIExamples?: AI.Node;
     genUIComponentNames?: string[];
+
+    /**
+     * If true, the Sidekick will emit next steps recommendations, such as:
+     *
+     *    ...and that's some detail about your most recent order.
+     *
+     *    <NextStepsButton prompt='What other orders are there?' />
+     *    <NextStepsButton prompt='How do I cancel the order?' />
+     *    <NextStepsButton prompt='How do I resubmit the order?' />
+     *
+     * Defaults to true.
+     */
+    includeNextStepsRecommendations?: boolean;
   },
   {
     /**
@@ -86,6 +99,7 @@ export function Sidekick(props: SidekickProps) {
             timeZone="America/Los_Angeles"
             timeZoneOffset="420"
             role={props.role}
+            includeNextStepsRecommendations={props.includeNextStepsRecommendations ?? true}
             outputFormat={props.outputFormat ?? 'text/mdx'}
             userProvidedGenUIUsageExamples={props.genUIExamples}
             userProvidedGenUIComponentNames={props.genUIComponentNames}

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -77,6 +77,7 @@ export function Sidekick(props: SidekickProps) {
             timeZone="America/Los_Angeles"
             timeZoneOffset="420"
             role={props.role}
+            outputFormat={props.outputFormat ?? 'text/gen-ui'}
             userProvidedGenUIUsageExamples={props.genUIExamples}
             userProvidedGenUIComponentNames={props.genUIComponentNames}
           />

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -5,6 +5,7 @@ import { OpenAI } from '../../../lib/openai.js';
 import { UseToolsProps } from '../../use-tools.js';
 import * as AI from '../../../index.js';
 import { ConversationHistory, ShowConversation } from '../../../core/conversation.js';
+import { MergeExclusive } from 'type-fest';
 
 export type OpenAIChatModel = Exclude<Parameters<typeof OpenAI>[0]['chatModel'], undefined>;
 export type ModelProvider = 'openai';
@@ -38,18 +39,30 @@ export function ModelProvider({
   }
 }
 
-export interface SidekickProps {
+interface UniversalSidekickProps {
   tools?: UseToolsProps['tools'];
   systemMessage?: AI.Node;
   finalSystemMessageBeforeResponse?: AI.Node;
-  genUIExamples?: AI.Node;
-  genUIComponentNames?: string[];
 
   /**
-   * The role the model should take, like "a customer service agent for Help Scout".
+   * The role the model should take, like "a customer service agent for my_company_name".
    */
   role: string;
 }
+
+type OutputFormatSidekickProps = MergeExclusive<
+  {
+    outputFormat: 'text/gen-ui' | undefined;
+
+    genUIExamples?: AI.Node;
+    genUIComponentNames?: string[];
+  },
+  {
+    outputFormat: 'text/markdown' | 'text/plain';
+  }
+>;
+
+export type SidekickProps = UniversalSidekickProps & OutputFormatSidekickProps;
 
 export function Sidekick(props: SidekickProps) {
   return (

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -3,8 +3,9 @@ import { MdxSystemMessage } from '../../../react/jit-ui/mdx.js';
 import { Prompt } from '../../prompts.js';
 import { mdxUsageExamples } from './gen-ui.js';
 import { Node } from '../../../index.js';
+import { SidekickProps } from './sidekick.js';
 
-export interface SidekickSystemMessageProps {
+export interface SidekickSystemMessageProps extends Pick<SidekickProps, 'outputFormat'> {
   timeZone: string;
   timeZoneOffset: string;
   userProvidedGenUIUsageExamples?: Node;
@@ -17,6 +18,7 @@ export function SidekickSystemMessage({
   timeZoneOffset,
   userProvidedGenUIUsageExamples,
   userProvidedGenUIComponentNames,
+  outputFormat,
   role,
 }: SidekickSystemMessageProps) {
   const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -51,15 +53,20 @@ export function SidekickSystemMessage({
         If the user asks something that is impossible, tell them **up-front** it is impossible. You can still write
         relevant helpful comments, but do not lead the user to think something can be done when it cannot be.
       </SystemMessage>
-      <MdxSystemMessage
-        componentNames={['Card', 'Citation', 'NextStepsButton', ...(userProvidedGenUIComponentNames ?? [])]}
-        usageExamples={
-          <>
-            {mdxUsageExamples}
-            {userProvidedGenUIUsageExamples}
-          </>
-        }
-      />
+      {outputFormat === 'text/markdown' && <SystemMessage>
+        Respond with Markdown.  
+      </SystemMessage>}
+      {outputFormat === 'text/gen-ui' && (
+        <MdxSystemMessage
+          componentNames={['Card', 'Citation', 'NextStepsButton', ...(userProvidedGenUIComponentNames ?? [])]}
+          usageExamples={
+            <>
+              {mdxUsageExamples}
+              {userProvidedGenUIUsageExamples}
+            </>
+          }
+        />
+      )}
     </>
   );
 }

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -1,11 +1,12 @@
 import { SystemMessage } from '../../../core/conversation.js';
 import { MdxSystemMessage } from '../../../react/jit-ui/mdx.js';
 import { Prompt } from '../../prompts.js';
-import { mdxUsageExamples } from './gen-ui.js';
+import { MdxUsageExamples } from './gen-ui.js';
 import { Node } from '../../../index.js';
 import { SidekickProps } from './sidekick.js';
 
-export interface SidekickSystemMessageProps extends Pick<SidekickProps, 'outputFormat'> {
+export interface SidekickSystemMessageProps
+  extends Pick<SidekickProps, 'outputFormat' | 'includeNextStepsRecommendations'> {
   timeZone: string;
   timeZoneOffset: string;
   userProvidedGenUIUsageExamples?: Node;
@@ -18,6 +19,7 @@ export function SidekickSystemMessage({
   timeZoneOffset,
   userProvidedGenUIUsageExamples,
   userProvidedGenUIComponentNames,
+  includeNextStepsRecommendations,
   outputFormat,
   role,
 }: SidekickSystemMessageProps) {
@@ -41,6 +43,11 @@ export function SidekickSystemMessage({
     </SystemMessage>
   );
 
+  const baseComponentNames = ['Card', 'Citation'];
+  if (includeNextStepsRecommendations) {
+    baseComponentNames.push('NextStepsButton');
+  }
+
   return (
     <>
       {dateTimeSystemMessage}
@@ -56,10 +63,10 @@ export function SidekickSystemMessage({
       {outputFormat === 'text/markdown' && <SystemMessage>Respond with Markdown.</SystemMessage>}
       {outputFormat === 'text/mdx' && (
         <MdxSystemMessage
-          componentNames={['Card', 'Citation', 'NextStepsButton', ...(userProvidedGenUIComponentNames ?? [])]}
+          componentNames={[...baseComponentNames, ...(userProvidedGenUIComponentNames ?? [])]}
           usageExamples={
             <>
-              {mdxUsageExamples}
+              <MdxUsageExamples includeNextStepsRecommendations={includeNextStepsRecommendations} />
               {userProvidedGenUIUsageExamples}
             </>
           }

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -54,7 +54,7 @@ export function SidekickSystemMessage({
         relevant helpful comments, but do not lead the user to think something can be done when it cannot be.
       </SystemMessage>
       {outputFormat === 'text/markdown' && <SystemMessage>Respond with Markdown.</SystemMessage>}
-      {outputFormat === 'text/gen-ui' && (
+      {outputFormat === 'text/mdx' && (
         <MdxSystemMessage
           componentNames={['Card', 'Citation', 'NextStepsButton', ...(userProvidedGenUIComponentNames ?? [])]}
           usageExamples={

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -53,9 +53,7 @@ export function SidekickSystemMessage({
         If the user asks something that is impossible, tell them **up-front** it is impossible. You can still write
         relevant helpful comments, but do not lead the user to think something can be done when it cannot be.
       </SystemMessage>
-      {outputFormat === 'text/markdown' && <SystemMessage>
-        Respond with Markdown.  
-      </SystemMessage>}
+      {outputFormat === 'text/markdown' && <SystemMessage>Respond with Markdown.</SystemMessage>}
       {outputFormat === 'text/gen-ui' && (
         <MdxSystemMessage
           componentNames={['Card', 'Citation', 'NextStepsButton', ...(userProvidedGenUIComponentNames ?? [])]}

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## 0.18.0
+## 0.18.1
+
+- Modified `Sidekick` to add the following options:
+  - `outputFormat`: `text/mdx`, `text/markdown`, `text/plain`
+  - `includeNextStepsRecommendations`: `boolean`
+
+## [0.18.0](https://github.com/fixie-ai/ai-jsx/commit/36b9f02c866df9df761017fd9f8785d876d15ab8)
 
 - Added components for Automatic Speech Recognition (ASR) in `lib/asr/asr.tsx`.
 - Addec components for Text-to-Speech (TTS) in `lib/tts/tts.tsx`.
 - ASR providers include Deepgram, Speechmatics, Assembly AI, Rev AI, Soniox, and Gladia.
 - TTS providers include Google Cloud, AWS, Azure, and ElevenLabs.
 
-## 0.17.4
+## [0.17.4](https://github.com/fixie-ai/ai-jsx/commit/b002c00d3926e03769438b01443c1bb715ade496)
 
 - Fixed a bug where passing an empty `functionDefinitions` prop to `<OpenAIChatModel>` would cause an error.
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -36,6 +36,7 @@
     "demo:context": "yarn build && node dist/src/context.js",
     "demo:multi-model": "yarn build && node dist/src/multi-model.js",
     "demo:opentelemetry": "yarn build && node dist/src/opentelemetry.js",
+    "demo:sidekick-output-format": "yarn build && node dist/src/sidekick-output-format.js",
     "demo:wandb": "yarn build && node dist/src/wandb.js",
     "demo:helloworld": "yarn build && node dist/src/helloworld.js",
     "demo:inline-chat": "yarn build && node dist/src/inline-chat.js",

--- a/packages/examples/src/sidekick-output-format.tsx
+++ b/packages/examples/src/sidekick-output-format.tsx
@@ -1,0 +1,39 @@
+import * as AI from 'ai-jsx';
+import { Sidekick, SidekickProps } from 'ai-jsx/sidekick';
+import { ConversationHistoryContext, SystemMessage, UserMessage } from 'ai-jsx/core/conversation';
+
+const mySystemMessage = (
+  <SystemMessage>
+    Here is information about the user's upcoming flight:
+    {`{
+    "flightNumber": "UA 123",
+    "departureTime": "2021-10-31T12:00:00Z",
+    "arrivalTime": "2021-10-31T13:00:00Z",
+    "departureAirport": "SFO",
+    "arrivalAirport": "LAX"
+  }`}
+  </SystemMessage>
+);
+
+function MySidekick({ contentType }: { contentType: SidekickProps['outputFormat'] }) {
+  return <Sidekick role="Flight assistant" outputFormat={contentType} systemMessage={mySystemMessage} />;
+}
+
+const conversation = [<UserMessage>Tell me about my flight. Also, give me a list of cities near my destination.</UserMessage>];
+
+console.log(
+  await AI.createRenderContext().render(
+    <>
+      <ConversationHistoryContext.Provider value={conversation}>
+        GenUI output:{'\n'}
+        <MySidekick contentType="text/gen-ui" />
+        {'\n\n'}
+        Markdown output:{'\n'}
+        <MySidekick contentType="text/markdown" />
+        {'\n\n'}
+        Plain text output:{'\n'}
+        <MySidekick contentType="text/plain" />
+      </ConversationHistoryContext.Provider>
+    </>
+  )
+);

--- a/packages/examples/src/sidekick-output-format.tsx
+++ b/packages/examples/src/sidekick-output-format.tsx
@@ -19,7 +19,9 @@ function MySidekick({ contentType }: { contentType: SidekickProps['outputFormat'
   return <Sidekick role="Flight assistant" outputFormat={contentType} systemMessage={mySystemMessage} />;
 }
 
-const conversation = [<UserMessage>Tell me about my flight. Also, give me a list of cities near my destination.</UserMessage>];
+const conversation = [
+  <UserMessage>Tell me about my flight. Also, give me a list of cities near my destination.</UserMessage>,
+];
 
 console.log(
   await AI.createRenderContext().render(

--- a/packages/examples/src/sidekick-output-format.tsx
+++ b/packages/examples/src/sidekick-output-format.tsx
@@ -4,7 +4,8 @@ import { ConversationHistoryContext, SystemMessage, UserMessage } from 'ai-jsx/c
 
 const mySystemMessage = (
   <SystemMessage>
-    Here is information about the user's upcoming flight:
+    You can do anything a flight assistant can do, including looking up user information and booking new flights. Here
+    is information about the user's upcoming flight:
     {`{
     "flightNumber": "UA 123",
     "departureTime": "2021-10-31T12:00:00Z",
@@ -15,8 +16,23 @@ const mySystemMessage = (
   </SystemMessage>
 );
 
-function MySidekick({ contentType }: { contentType: SidekickProps['outputFormat'] }) {
-  return <Sidekick role="Flight assistant" outputFormat={contentType} systemMessage={mySystemMessage} />;
+function MySidekick({
+  contentType,
+  includeNextStepsRecommendations,
+}: {
+  contentType: SidekickProps['outputFormat'];
+  includeNextStepsRecommendations?: boolean;
+}) {
+  // I don't feel like making the types line up.
+  // @ts-expect-error
+  return (
+    <Sidekick
+      role="Flight assistant"
+      outputFormat={contentType}
+      systemMessage={mySystemMessage}
+      includeNextStepsRecommendations={includeNextStepsRecommendations}
+    />
+  );
 }
 
 const conversation = [
@@ -27,8 +43,14 @@ console.log(
   await AI.createRenderContext().render(
     <>
       <ConversationHistoryContext.Provider value={conversation}>
+        {/* Unfortunately, I couldn't get this to actually output next steps buttons, but I confirmed that the prompt
+          is being passed.
+         */}
         GenUI output:{'\n'}
-        <MySidekick contentType="text/gen-ui" />
+        <MySidekick contentType="text/mdx" />
+        {'\n\n'}
+        GenUI output no next steps:{'\n'}
+        <MySidekick contentType="text/mdx" includeNextStepsRecommendations={false} />
         {'\n\n'}
         Markdown output:{'\n'}
         <MySidekick contentType="text/markdown" />

--- a/packages/examples/src/sidekick-output-format.tsx
+++ b/packages/examples/src/sidekick-output-format.tsx
@@ -23,9 +23,9 @@ function MySidekick({
   contentType: SidekickProps['outputFormat'];
   includeNextStepsRecommendations?: boolean;
 }) {
-  // I don't feel like making the types line up.
-  // @ts-expect-error
   return (
+    // I don't feel like making the types line up.
+    // @ts-expect-error
     <Sidekick
       role="Flight assistant"
       outputFormat={contentType}


### PR DESCRIPTION
Previously, the Sidekick would always emit GenUI components (e.g. `<Card>`). This can present a challenge for integrators, because using this output requires you to do MDX compilation. 

Now, we introduce three options:
* GenUI
* Plain Markdown
* Plain text

The latter option offers the lowest barrier to entry for integrators.

Also adds option to disable recommended next steps