### PR TITLE
Remove unused field `environment` when doing `fixie deploy`

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.4.0-1",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -314,7 +314,6 @@ export class FixieAgent {
         externalDeployment: opts.externalUrl && { url: opts.externalUrl },
         managedDeployment: opts.tarball &&
           uploadFile && {
-            environment: 'NODEJS',
             codePackage: new Blob([uploadFile], { type: 'application/gzip' }),
             environmentVariables: Object.entries(opts.environmentVariables).map(([key, value]) => ({
               name: key,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13001,29 +13001,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"fixie@npm:*":
-  version: 1.3.7
-  resolution: "fixie@npm:1.3.7"
-  dependencies:
-    "@apollo/client": ^3.8.1
-    apollo-upload-client: ^17.0.0
-    axios: ^1.5.0
-    commander: ^11.0.0
-    execa: ^8.0.1
-    extract-files: ^13.0.0
-    graphql: ^16.8.0
-    js-yaml: ^4.1.0
-    open: ^9.1.0
-    ora: ^7.0.1
-    terminal-kit: ^3.0.0
-    untildify: ^5.0.0
-  bin:
-    fixie: dist/src/main.js
-  checksum: eab7ec309c3f80070ec093498d3e8d92706e94cad2bb89a69ae697974cebc4aca44e7141ddd6368ebe9e68d6fa64b1a3cbea3ca09355879abcd43593de2cde67
-  languageName: node
-  linkType: hard
-
-"fixie@workspace:packages/fixie":
+"fixie@*, fixie@workspace:packages/fixie":
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:


### PR DESCRIPTION
I'm going to YOLO this in unless y'all object
