### PR TITLE
Incorporate `fixie` docs into generated API documentation.

### DIFF
--- a/packages/ai-jsx/readme.md
+++ b/packages/ai-jsx/readme.md
@@ -57,7 +57,7 @@ For a full set of examples, see [the examples package](https://github.com/fixie-
 
 ## Contributing
 
-We welcome contributions! See the [Contribution Guide](packages/docs/docs/contributing/index.md) for details on how to get started.
+We welcome contributions! See the [Contribution Guide](../contributing/index.md) for details on how to get started.
 
 ## License
 

--- a/packages/ai-jsx/tsconfig.json
+++ b/packages/ai-jsx/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig-base.json",
   "include": ["src/**/*", ".eslintrc.cjs"],
   "compilerOptions": {
-    "outDir": "dist/esm"
+    "outDir": "dist/esm",
+    "rootDir": "./src"
   },
   "typedocOptions": {
     "entryPoints": [

--- a/packages/ai-jsx/typedoc.json
+++ b/packages/ai-jsx/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/docs/docs/ai-newcomers.md
+++ b/packages/docs/docs/ai-newcomers.md
@@ -138,7 +138,7 @@ const tools: Record<string, Tool> = {
 </UseTools>;
 ```
 
-More detail: [`UseTools` API docs](../api/modules/batteries_use_tools#usetools).
+More detail: [`UseTools` API docs](../api/modules/ai_jsx.batteries_use_tools#usetools).
 
 ### Accessing Knowledge (AKA "Docs QA")
 

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -167,7 +167,7 @@
 ## [0.5.10](https://github.com/fixie-ai/ai-jsx/commit/e2735fde8c33e3019a074c29824206d9725eed64)
 
 - Update logging to log the output of every component.
-- Update [`UseTools`](./api/modules/batteries_use_tools.md) to use [OpenAI function calls](https://openai.com/blog/function-calling-and-other-api-updates) if you're using a model that supports them.
+- Update [`UseTools`](./api/modules/ai_jsx.batteries_use_tools.md) to use [OpenAI function calls](https://openai.com/blog/function-calling-and-other-api-updates) if you're using a model that supports them.
 
 ## [0.5.9](https://github.com/fixie-ai/ai-jsx/commit/92b6e0f28580fbd9b8fb62072d8c13e28b14d9fe)
 
@@ -175,13 +175,13 @@
 
 ## [0.5.8](https://github.com/fixie-ai/ai-jsx/commit/89c87a8ed6d394ce443ad074ae38152f54c7bddc)
 
-- [`ImageGen`](./api/modules/core_image_gen.md#image) now produces an [`Image`](./api/modules/core_image_gen.md#image) object which will render to a URL in the command line, but returns an `<img />` tag when using in the browser (React/Next).
+- [`ImageGen`](./api/modules/ai_jsx.core_image_gen.md#image) now produces an [`Image`](./api/modules/ai_jsx.core_image_gen.md#image) object which will render to a URL in the command line, but returns an `<img />` tag when using in the browser (React/Next).
 
 ## [0.5.7](https://github.com/fixie-ai/ai-jsx/commit/8c29bb65fa2d4d26893eabebf5aa63f1506703e7)
 
 - Add ability to stream UI components in the [UI on the client; AI.JSX on the server](./guides/architecture.mdx#ui-on-the-client-aijsx-on-the-server) architecture pattern.
 - Add ability to do append-only text streaming.
-- Update [`UseTools`](./api/modules/batteries_use_tools.md) to match [OpenAI function syntax](https://openai.com/blog/function-calling-and-other-api-updates).
+- Update [`UseTools`](./api/modules/ai_jsx.batteries_use_tools.md) to match [OpenAI function syntax](https://openai.com/blog/function-calling-and-other-api-updates).
 - Add `ConversationalHistory` component.
 
 ## [0.5.6](https://github.com/fixie-ai/ai-jsx/commit/92c34d97687bfdb7ed839b78fef3b4683acd0756)

--- a/packages/docs/docs/contributing/index.md
+++ b/packages/docs/docs/contributing/index.md
@@ -62,7 +62,7 @@ To publish:
 1. During your PR:
 
    1. Make sure the `version` field in `packages/ai-jsx/package.json` has been incremented in accordance with [semver](https://semver.org/).
-   1. Update the [changelog](../changelog.md). In addition to adding a section describing
+   1. Update the changelog. In addition to adding a section describing
       the changes in the new version, be sure to update the heading for the previous version
       with a link to the commit for that version, for example:
 

--- a/packages/docs/docs/guides/docsqa.md
+++ b/packages/docs/docs/guides/docsqa.md
@@ -37,7 +37,7 @@ When using a Fixie corpus, Fixie can handle parsing for most common documents ty
 
 ### Step 2: Vectorizing
 
-Now that you have text documents, you'll need to split them into "chunks" so that several can fit in your LLM's [context window](../ai-newcomers.md#context-window) and you'll need to [embed](../ai-newcomers.md#semantic-similarity-embeddings) them into your corpus's vector space. These are done with a [`Chunker`](../api/modules/batteries_docs#chunker) and an [`Embedding`](../api/interfaces/batteries_docs.Embedding.md) respectively. AI.JSX provides defaults for each of these, but you're free to swap these out however you'd like. This could be especially useful when combined with a custom loader and parser for non-text documents since there may be semantic meaning that could be inferred from the document structure itself that wouldn't necessarily be captured by the defaults.
+Now that you have text documents, you'll need to split them into "chunks" so that several can fit in your LLM's [context window](../ai-newcomers.md#context-window) and you'll need to [embed](../ai-newcomers.md#semantic-similarity-embeddings) them into your corpus's vector space. These are done with a [`Chunker`](../api/modules/ai_jsx.batteries_docs#chunker) and an [`Embedding`](../api/interfaces/ai_jsx.batteries_docs.Embedding.md) respectively. AI.JSX provides defaults for each of these, but you're free to swap these out however you'd like. This could be especially useful when combined with a custom loader and parser for non-text documents since there may be semantic meaning that could be inferred from the document structure itself that wouldn't necessarily be captured by the defaults.
 
 See also: [Pinecone Guidance on Chunking Strategies](https://www.pinecone.io/learn/chunking-strategies/).
 
@@ -45,7 +45,7 @@ With vectors in hand, your text chunks can be added to a vector database. When r
 
 ### Starting and Monitoring Loading
 
-The AI.JSX [`LoadableCorpus`](../api/classes/batteries_docs.LoadableCorpus) interface provides a [`load`](../api/classes/batteries_docs.LoadableCorpus#load) method that will begin loading and vectorizing documents so they're available for querying later. It also provides a [`getStats`](../api/classes/batteries_docs.LoadableCorpus#getstats) method so you can inspect a corpus's progress.
+The AI.JSX [`LoadableCorpus`](../api/classes/ai_jsx.batteries_docs.LoadableCorpus) interface provides a [`load`](../api/classes/ai_jsx.batteries_docs.LoadableCorpus#load) method that will begin loading and vectorizing documents so they're available for querying later. It also provides a [`getStats`](../api/classes/ai_jsx.batteries_docs.LoadableCorpus#getstats) method so you can inspect a corpus's progress.
 
 ```typescript
 // Have the corpus begin loading. This promise may take a while to resolve, but we'll be ready to
@@ -86,7 +86,7 @@ flowchart LR
   que[Query] -->|string| embed2[Embed] -->|vector| vdb2[(Vector DB)] -->|similar chunks| LLM
 ```
 
-If you use the built-in [`DocsQA`](../api/modules/batteries_docs.md#docsqa) component from AI.JSX, then you just need to decide how to present the chunk to your LLM:
+If you use the built-in [`DocsQA`](../api/modules/ai_jsx.batteries_docs.md#docsqa) component from AI.JSX, then you just need to decide how to present the chunk to your LLM:
 
 ```typescript
 function ShowDoc({ doc }: { doc: Document<MyDocMetadata> }) {
@@ -118,7 +118,7 @@ The `DocsQA` component provides an answer, like:
 */
 ```
 
-If you want an answer that cites sources, use [`DocsQAWithCitations`](../api/modules/batteries_docs.md#docsqawithcitations):
+If you want an answer that cites sources, use [`DocsQAWithCitations`](../api/modules/ai_jsx.batteries_docs.md#docsqawithcitations):
 
 ```tsx
 <DocsQAWithCitations question="What is the atomic number of nitrogen?" corpus={corpus} docComponent={ShowDoc} />

--- a/packages/docs/docs/guides/prompting.md
+++ b/packages/docs/docs/guides/prompting.md
@@ -27,7 +27,7 @@ function App() {
 
 [`ChatCompletion`](../api/modules/core_completion?_highlight=chatcompletion#chatcompletion) is preferred to [`Completion`](../api/modules/core_completion?_highlight=chatcompletion#completion) because all the most powerful models are chat-based, and [it's best to start with the most powerful models](../ai-newcomers.md#recommended-dev-workflow).
 
-To configure the output of `ChatCompletion`, use [`ModelProps`](../api/interfaces/core_completion.ModelProps.md). This allows you to do things like making the model more creative or precise, telling the model how long a response you want back, etc. Combined with the natural language of your [prompt](../ai-newcomers.md#prompt-engineering), this is how you control the model's output.
+To configure the output of `ChatCompletion`, use [`ModelProps`](../api/interfaces/ai_jsx.core_completion.ModelProps.md). This allows you to do things like making the model more creative or precise, telling the model how long a response you want back, etc. Combined with the natural language of your [prompt](../ai-newcomers.md#prompt-engineering), this is how you control the model's output.
 
 ## The Problem with Non-Chat Models
 

--- a/packages/docs/docs/guides/rules-of-jsx.md
+++ b/packages/docs/docs/guides/rules-of-jsx.md
@@ -111,7 +111,7 @@ function* GenerateImage() {
 
 AI.JSX will interpret each `yield`ed value as a new value which should totally overwrite the previously-yielded values, so the caller would see a progression of increasingly high-quality images.
 
-However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/core_render.md#appendonlystream) value to indicate that `yield`ed results should be interpreted as deltas:
+However, sometimes your data source will give you deltas, so replacing the previous contents doesn't make much sense. In this case, `yield` the [`AppendOnlyStream`](../api/modules/ai_jsx.core_render.md#appendonlystream) value to indicate that `yield`ed results should be interpreted as deltas:
 
 ```tsx
 import * as AI from 'ai-jsx';
@@ -128,13 +128,13 @@ function* GenerateText() {
 
 ## Component API
 
-Components take props as the first argument and [`ComponentContext`](../api/interfaces/core_render.ComponentContext) as the second:
+Components take props as the first argument and [`ComponentContext`](../api/interfaces/ai_jsx.core_render.ComponentContext) as the second:
 
 ```tsx
 function MyComponent(props, componentContext) {}
 ```
 
-`componentContext` contains a [`render`](../api/interfaces/core_render.ComponentContext#render) method, which you can use to [render other JSX components](./rendering.md#rendering-from-a-component).
+`componentContext` contains a [`render`](../api/interfaces/ai_jsx.core_render.ComponentContext#render) method, which you can use to [render other JSX components](./rendering.md#rendering-from-a-component).
 
 ### Context
 

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -38,14 +38,15 @@ const config = {
     [
       'docusaurus-plugin-typedoc',
       {
-        // If you add new public-facing entry points, please ensure that they are listed below
-        // so that the published API documentation will include them.
-        tsconfig: '../ai-jsx/tsconfig.json',
+        entryPoints: ['../ai-jsx', '../fixie'],
+        entryPointStrategy: 'packages',
+        includeVersion: true,
+        out: 'api',
         sidebar: {
+          fullNames: false,
           categoryLabel: 'API Reference',
           collapsed: true,
           position: 20,
-          fullNames: true,
         },
       },
     ],
@@ -108,7 +109,7 @@ const config = {
           {
             to: 'api/',
             position: 'left',
-            label: 'API',
+            label: 'API Reference',
           },
           {
             href: process.env.GITHUB_URL,

--- a/packages/fixie/tsconfig.json
+++ b/packages/fixie/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "strict": true,
     "noEmitOnError": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/fixie/typedoc.json
+++ b/packages/fixie/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["./index.ts"]
+}

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ For a full set of examples, see [the examples package](https://github.com/fixie-
 
 ## Contributing
 
-We welcome contributions! See the [Contribution Guide](packages/docs/docs/contributing/index.md) for details on how to get started.
+We welcome contributions! See the [Contribution Guide](../contributing/index.md) for details on how to get started.
 
 ## License
 


### PR DESCRIPTION
This PR incorporates the autogenerated documentation for the `fixie` package in the API Reference docs for ai-jsx.com.

There are several ways of doing this, apparently, in a monorepo like ours. This approach merges all of the API docs together. There are many configuration options we could explore if this doesn't work well, but I think it's good to start with something rather than nothing!
