### PR TITLE
Don't use workspace dependency in fixie package.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.1",
     "@types/apollo-upload-client": "^17.0.2",
-    "ai-jsx": "workspace:*",
+    "ai-jsx": "^0.18.1",
     "apollo-upload-client": "^17.0.0",
     "axios": "^1.5.0",
     "commander": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7492,7 +7492,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"ai-jsx@*, ai-jsx@>=0.12.0 <1.0.0, ai-jsx@workspace:*, ai-jsx@workspace:packages/ai-jsx":
+"ai-jsx@*, ai-jsx@>=0.12.0 <1.0.0, ai-jsx@^0.18.1, ai-jsx@workspace:*, ai-jsx@workspace:packages/ai-jsx":
   version: 0.0.0-use.local
   resolution: "ai-jsx@workspace:packages/ai-jsx"
   dependencies:
@@ -13024,7 +13024,7 @@ __metadata:
     "@types/terminal-kit": ^2.5.1
     "@typescript-eslint/eslint-plugin": ^5.60.0
     "@typescript-eslint/parser": ^5.60.0
-    ai-jsx: "workspace:*"
+    ai-jsx: ^0.18.1
     apollo-upload-client: ^17.0.0
     axios: ^1.5.0
     commander: ^11.0.0


### PR DESCRIPTION
This breaks the published `fixie` package which complains about the "workspace:" dependency.