### PR TITLE
Try to be more robust about subprocess death.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -531,11 +531,15 @@ export class FixieAgent {
       console.log(`🌱 Restarting local agent process due to ${event}: ${targetPath}`);
       agentProcess.kill();
       // Let it shut down gracefully.
-      await new Promise<void>((resolve) =>
-        agentProcess.exitCode !== null || agentProcess.signalCode !== null
-          ? resolve()
-          : agentProcess.on('exit', resolve)
-      );
+      await new Promise<void>((resolve) => {
+        if (agentProcess.exitCode !== null || agentProcess.signalCode !== null) {
+          resolve();
+        } else {
+          agentProcess.on('close', () => {
+            resolve();
+          });
+        }
+      });
       agentProcess = FixieAgent.spawnAgentProcess(agentPath, port, environmentVariables);
     });
 


### PR DESCRIPTION
Trying to fix @benlower's issue where the agent restarts before the port is released. Apparently `close` happens after `exit` so maybe this will fix it?