### PR TITLE
Preload tokenizer to avoid long delay on first generation

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/debug.tsx
+++ b/packages/ai-jsx/src/core/debug.tsx
@@ -150,10 +150,16 @@ export function debug(value: unknown, expandJSXChildren: boolean = true): string
           return `[${values.join(', ')}]`;
       }
     } else if (typeof value === 'object') {
-      if (context === 'props' || context === 'children') {
-        return `{${JSON.stringify(value)}}`;
+      let stringified;
+      try {
+        stringified = JSON.stringify(value);
+      } catch {
+        stringified = '{/* ... */}';
       }
-      return JSON.stringify(value);
+      if (context === 'props' || context === 'children') {
+        return `{${stringified}}`;
+      }
+      return stringified;
     } else if (typeof value === 'function') {
       const toRender = value.name === '' ? value.toString() : value.name;
       if (context === 'props' || context === 'children') {

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -22,7 +22,8 @@ import { OpenAI as OpenAIClient } from 'openai';
 export { OpenAI as OpenAIClient } from 'openai';
 import { FinalRequestOptions } from 'openai/core';
 import { debugRepresentation } from '../core/debug.js';
-import { getEncoding } from 'js-tiktoken';
+import cl100k_base from 'js-tiktoken/ranks/cl100k_base';
+import { Tiktoken } from 'js-tiktoken/lite';
 import _ from 'lodash';
 
 // https://platform.openai.com/docs/models/model-endpoint-compatibility
@@ -131,10 +132,14 @@ export function OpenAI({
   return result;
 }
 
-const getEncoder = _.once(() => getEncoding('cl100k_base'));
+// Preload the tokenizer to avoid a large delay on first use.
+const tiktoken = new Tiktoken(cl100k_base);
+export const tokenizer = {
+  encode: (text: string) => tiktoken.encode(text),
+  decode: (tokens: number[]) => tiktoken.decode(tokens),
+};
 
 function logitBiasOfTokens(tokens: Record<string, number>) {
-  const tokenizer = getEncoder();
   return Object.fromEntries(
     Object.entries(tokens).map(([token, bias]) => {
       const encoded = tokenizer.encode(token);
@@ -213,7 +218,7 @@ function estimateFunctionTokenCount(functions: Record<string, FunctionDefinition
   // According to https://community.openai.com/t/how-to-calculate-the-tokens-when-using-function-call/266573
   // function definitions are serialized as TypeScript. We'll use JSON-serialization as an approximation (which
   // is almost certainly an overestimate).
-  return getEncoder().encode(JSON.stringify(functions)).length;
+  return tokenizer.encode(JSON.stringify(functions)).length;
 }
 
 function tokenLimitForChatModel(
@@ -251,30 +256,29 @@ async function tokenCountForConversationMessage(
 ): Promise<number> {
   const TOKENS_PER_MESSAGE = 3;
   const TOKENS_PER_NAME = 1;
-  const encoder = getEncoder();
   switch (message.type) {
     case 'user':
       return (
         TOKENS_PER_MESSAGE +
-        encoder.encode(await render(message.element)).length +
-        (message.element.props.name ? encoder.encode(message.element.props.name).length + TOKENS_PER_NAME : 0)
+        tokenizer.encode(await render(message.element)).length +
+        (message.element.props.name ? tokenizer.encode(message.element.props.name).length + TOKENS_PER_NAME : 0)
       );
     case 'assistant':
     case 'system':
-      return TOKENS_PER_MESSAGE + encoder.encode(await render(message.element)).length;
+      return TOKENS_PER_MESSAGE + tokenizer.encode(await render(message.element)).length;
     case 'functionCall':
       return (
         TOKENS_PER_MESSAGE +
         TOKENS_PER_NAME +
-        encoder.encode(message.element.props.name).length +
-        encoder.encode(JSON.stringify(message.element.props.args)).length
+        tokenizer.encode(message.element.props.name).length +
+        tokenizer.encode(JSON.stringify(message.element.props.args)).length
       );
     case 'functionResponse':
       return (
         TOKENS_PER_MESSAGE +
         TOKENS_PER_NAME +
-        encoder.encode(await render(message.element.props.children)).length +
-        encoder.encode(message.element.props.name).length
+        tokenizer.encode(await render(message.element.props.children)).length +
+        tokenizer.encode(message.element.props.name).length
       );
   }
 }

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -133,10 +133,10 @@ export function OpenAI({
 }
 
 // Preload the tokenizer to avoid a large delay on first use.
-const tiktoken = new Tiktoken(cl100k_base);
+const cl100kTokenizer = new Tiktoken(cl100k_base);
 export const tokenizer = {
-  encode: (text: string) => tiktoken.encode(text),
-  decode: (tokens: number[]) => tiktoken.decode(tokens),
+  encode: (text: string) => cl100kTokenizer.encode(text),
+  decode: (tokens: number[]) => cl100kTokenizer.decode(tokens),
 };
 
 function logitBiasOfTokens(tokens: Record<string, number>) {

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.18.1
+## 0.18.2
+
+- Modified `lib/openai` to preload the tokenizer to avoid a stall on first use
+- Fixed an issue where `debug(component)` would throw an exception if a component had a prop that could not be JSON-serialized.
+
+## [0.18.1](https://github.com/fixie-ai/ai-jsx/commit/956ce578eb03f9fd269ae043fa514a7cf711bb06)
 
 - Modified `Sidekick` to add the following options:
   - `outputFormat`: `text/mdx`, `text/markdown`, `text/plain`

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.1",
     "@types/apollo-upload-client": "^17.0.2",
-    "ai-jsx": "^0.18.1",
+    "ai-jsx": "^0.18.2",
     "apollo-upload-client": "^17.0.0",
     "axios": "^1.5.0",
     "commander": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7492,7 +7492,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"ai-jsx@*, ai-jsx@>=0.12.0 <1.0.0, ai-jsx@^0.18.1, ai-jsx@workspace:*, ai-jsx@workspace:packages/ai-jsx":
+"ai-jsx@*, ai-jsx@>=0.12.0 <1.0.0, ai-jsx@^0.18.2, ai-jsx@workspace:*, ai-jsx@workspace:packages/ai-jsx":
   version: 0.0.0-use.local
   resolution: "ai-jsx@workspace:packages/ai-jsx"
   dependencies:
@@ -13024,7 +13024,7 @@ __metadata:
     "@types/terminal-kit": ^2.5.1
     "@typescript-eslint/eslint-plugin": ^5.60.0
     "@typescript-eslint/parser": ^5.60.0
-    ai-jsx: ^0.18.1
+    ai-jsx: ^0.18.2
     apollo-upload-client: ^17.0.0
     axios: ^1.5.0
     commander: ^11.0.0


### PR DESCRIPTION
Previously the OpenAI tokenizer was loaded lazily on first generation. Empirically, loading the tokenizer can take hundreds of ms, so this preloads it on module load rather than first use.

Also:
- Share the tokenizer instance between `LargeResponseHandler` and `ChatCompletion`
- Wrap `JSON.stringify` in `debug` with a try/catch and use a fallback value