### PR TITLE
Fix incorrect empty string handling

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -525,10 +525,8 @@ export async function ShrinkConversation(
     stop: (e) => isConversationalComponent(e) || e.tag === InternalShrinkable,
   });
 
-  assertNoMeaningfulStringContent(rendered);
-
   // If there are no shrinkable elements, there's no need to evaluate the cost.
-  const shrinkableOrConversationElements = rendered.filter(AI.isElement);
+  const shrinkableOrConversationElements = assertNoMeaningfulStringContent(rendered);
   if (!shrinkableOrConversationElements.find((value) => value.tag === InternalShrinkable)) {
     return shrinkableOrConversationElements;
   }

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -442,7 +442,7 @@ export async function ShrinkConversation(
       })
     );
 
-    return await Promise.all(
+    return Promise.all(
       rendered.map<Promise<TreeNode>>(async (value) => {
         if (value.tag === InternalShrinkable) {
           const children = await conversationToTreeRoots(value.props.children);

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.18.2
+## 0.18.3
+
+- Fix an issue where empty strings in conversational prompts cause errors to be thrown.
+
+## [0.18.2](https://github.com/fixie-ai/ai-jsx/commit/fc8ada2d9900b179252d377292835dc28998b86f)
 
 - Modified `lib/openai` to preload the tokenizer to avoid a stall on first use
 - Fixed an issue where `debug(component)` would throw an exception if a component had a prop that could not be JSON-serialized.


### PR DESCRIPTION
This fixes a bug where passing an empty string in a conversational prompt would cause errors to be thrown.