### PR TITLE
Rewrite use-fixie hook

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -35,7 +35,6 @@
     "lodash": "^4.17.21",
     "open": "^9.1.0",
     "ora": "^7.0.1",
-    "react-firebase-hooks": "^5.1.1",
     "terminal-kit": "^3.0.0",
     "untildify": "^5.0.0",
     "watcher": "^2.3.0"

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/fixie-embed.tsx
+++ b/packages/fixie/src/fixie-embed.tsx
@@ -26,12 +26,12 @@ export interface FixieEmbedProps extends React.IframeHTMLAttributes<HTMLIFrameEl
   inline?: boolean;
 
   /**
-   * If true, the agent will send a greeting message when the conversation starts. To make this work, you'll want to 
-   * either specify a hardcoded greeting message as part of the agent config, or update the agent system message to 
+   * If true, the agent will send a greeting message when the conversation starts. To make this work, you'll want to
+   * either specify a hardcoded greeting message as part of the agent config, or update the agent system message to
    * tell the agent how to start the conversation.
-   * 
+   *
    * If false, the agent will be silent until the user sends a message.
-   * 
+   *
    * Defaults to false.
    */
   agentSendsGreeting?: boolean;
@@ -49,8 +49,17 @@ const defaultFixieHost = 'https://fixie.vercel.app';
  *
  * Any extra props to this component are passed through to the `iframe`.
  */
-export function InlineFixieEmbed({ speak, debug, agentId, fixieHost, agentSendsGreeting, ...iframeProps }: FixieEmbedProps) {
-  return <iframe {...getBaseIframeProps({ speak, debug, agentId, fixieHost, agentSendsGreeting })} {...iframeProps}></iframe>;
+export function InlineFixieEmbed({
+  speak,
+  debug,
+  agentId,
+  fixieHost,
+  agentSendsGreeting,
+  ...iframeProps
+}: FixieEmbedProps) {
+  return (
+    <iframe {...getBaseIframeProps({ speak, debug, agentId, fixieHost, agentSendsGreeting })} {...iframeProps}></iframe>
+  );
 }
 
 export function ControlledFloatingFixieEmbed({

--- a/packages/fixie/src/fixie-embed.tsx
+++ b/packages/fixie/src/fixie-embed.tsx
@@ -26,6 +26,17 @@ export interface FixieEmbedProps extends React.IframeHTMLAttributes<HTMLIFrameEl
   inline?: boolean;
 
   /**
+   * If true, the agent will send a greeting message when the conversation starts. To make this work, you'll want to 
+   * either specify a hardcoded greeting message as part of the agent config, or update the agent system message to 
+   * tell the agent how to start the conversation.
+   * 
+   * If false, the agent will be silent until the user sends a message.
+   * 
+   * Defaults to false.
+   */
+  agentSendsGreeting?: boolean;
+
+  /**
    * If you're not sure whether you need this, the answer is "no".
    */
   fixieHost?: string;
@@ -38,14 +49,15 @@ const defaultFixieHost = 'https://fixie.vercel.app';
  *
  * Any extra props to this component are passed through to the `iframe`.
  */
-export function InlineFixieEmbed({ speak, debug, agentId, fixieHost, ...iframeProps }: FixieEmbedProps) {
-  return <iframe {...getBaseIframeProps({ speak, debug, agentId, fixieHost })} {...iframeProps}></iframe>;
+export function InlineFixieEmbed({ speak, debug, agentId, fixieHost, agentSendsGreeting, ...iframeProps }: FixieEmbedProps) {
+  return <iframe {...getBaseIframeProps({ speak, debug, agentId, fixieHost, agentSendsGreeting })} {...iframeProps}></iframe>;
 }
 
 export function ControlledFloatingFixieEmbed({
   visible,
   speak,
   debug,
+  agentSendsGreeting,
   agentId,
   fixieHost,
   ...iframeProps
@@ -79,7 +91,7 @@ export function ControlledFloatingFixieEmbed({
         // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
         // @ts-ignore
         <iframe
-          {...getBaseIframeProps({ speak, debug, agentId, fixieHost })}
+          {...getBaseIframeProps({ speak, debug, agentId, fixieHost, agentSendsGreeting })}
           {...iframeProps}
           style={chatStyle}
         ></iframe>,
@@ -149,15 +161,19 @@ export function FloatingFixieEmbed({ fixieHost, ...restProps }: FixieEmbedProps)
 function getBaseIframeProps({
   speak,
   debug,
+  agentSendsGreeting,
   fixieHost,
   agentId,
-}: Pick<FixieEmbedProps, 'speak' | 'debug' | 'fixieHost' | 'agentId'>) {
+}: Pick<FixieEmbedProps, 'speak' | 'debug' | 'fixieHost' | 'agentId' | 'agentSendsGreeting'>) {
   const embedUrl = new URL(`/embed/${agentId}`, fixieHost ?? defaultFixieHost);
   if (speak) {
     embedUrl.searchParams.set('speak', '1');
   }
   if (debug) {
     embedUrl.searchParams.set('debug', '1');
+  }
+  if (agentSendsGreeting) {
+    embedUrl.searchParams.set('agentStartsConversation', '1');
   }
 
   return {

--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -275,13 +275,13 @@ export class IsomorphicFixieClient {
    * Start a new conversation with an agent, optionally sending the initial message. (If you don't send the initial
    * message, the agent may.)
    *
- * @returns {Object} An object with the following properties:
- *    @property {string} conversationId - The conversation ID, which can be used with the other API methods to continue the
- *                                         conversation.
- *    @property {Object} response - The fetch response. The response will be a stream of newline-delimited JSON objects, 
- *                                  each of which be of the shape ConversationTurn. Each member of the stream is the latest 
- *                                  value of the turn as the agent streams its response. So, if you're driving a UI with this 
- *                                  response, you always want to render the most recently emitted value from the stream.
+   * @returns {Object} An object with the following properties:
+   *    @property {string} conversationId - The conversation ID, which can be used with the other API methods to continue the
+   *                                         conversation.
+   *    @property {Object} response - The fetch response. The response will be a stream of newline-delimited JSON objects,
+   *                                  each of which be of the shape ConversationTurn. Each member of the stream is the latest
+   *                                  value of the turn as the agent streams its response. So, if you're driving a UI with this
+   *                                  response, you always want to render the most recently emitted value from the stream.
    *
    *          If the generation is stopped via the stopGeneration() API, the final value emitted from the stream will be
    *          the same as what's persisted to the conversation history. However, intermediate stream values may include

--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -275,13 +275,13 @@ export class IsomorphicFixieClient {
    * Start a new conversation with an agent, optionally sending the initial message. (If you don't send the initial
    * message, the agent may.)
    *
-   * @returns { conversationId, response }
-   *    conversationId: The conversation ID, which can be used with the other API methods to continue the
-   *                               conversation.
-   *    response: The fetch response. The response will be a stream of newline-delimited JSON objects, each of which be
-   *              of the shape ConversationTurn. Each member of the stream is the latest value of the turn as the agent
-   *              streams its response. So, if you're driving a UI with this response, you always want to render the
-   *              most recently emitted value from the stream.
+ * @returns {Object} An object with the following properties:
+ *    @property {string} conversationId - The conversation ID, which can be used with the other API methods to continue the
+ *                                         conversation.
+ *    @property {Object} response - The fetch response. The response will be a stream of newline-delimited JSON objects, 
+ *                                  each of which be of the shape ConversationTurn. Each member of the stream is the latest 
+ *                                  value of the turn as the agent streams its response. So, if you're driving a UI with this 
+ *                                  response, you always want to render the most recently emitted value from the stream.
    *
    *          If the generation is stopped via the stopGeneration() API, the final value emitted from the stream will be
    *          the same as what's persisted to the conversation history. However, intermediate stream values may include

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -155,11 +155,6 @@ export function useFixie({
   const [input, setInput] = useState('');
   const [conversationId, setConversationId] = useState(userPassedConversationId);
 
-  function handleNewConversationId(conversationId: ConversationId) {
-    setConversationId(conversationId);
-    onNewConversation?.(conversationId);
-  }
-
   useEffect(() => {
     setConversationId(userPassedConversationId);
   }, [userPassedConversationId]);
@@ -227,12 +222,28 @@ export function useFixie({
   // We don't need the API key to access the conversation API.
   const fixieClient = IsomorphicFixieClient.CreateWithoutApiKey(fixieAPIUrl ?? 'https://api.fixie.ai');
 
+  // const [newConversationBeingCreated, setNewConversationBeingCreated] = useState(false);
+  const newConversationBeingCreatedButNoResponseTokensYet = useRef(false);
+
   const lastSeenMostRecentAgentTextMessage = useRef('');
   async function createNewConversation(overriddenInput?: string) {
-    const conversationId = (
+    // setNewConversationBeingCreated(true);
+    newConversationBeingCreatedButNoResponseTokensYet.current = true;
+    const {conversationId, response} = (
       await fixieClient.startConversation(agentId, fullMessageGenerationParams, overriddenInput ?? input)
-    ).conversationId;
-    handleNewConversationId(conversationId);
+    );
+
+    const decoder = new TextDecoder();
+    response.body?.pipeTo(new WritableStream({
+      write(chunk) {
+        // setNewConversationBeingCreated(false);
+        console.log('nth== response chunk', decoder.decode(chunk))
+        newConversationBeingCreatedButNoResponseTokensYet.current = false;
+      }
+    }));
+
+    setConversationId(conversationId);
+    onNewConversation?.(conversationId);
   }
 
   /**
@@ -442,6 +453,24 @@ export function useFixie({
     return loadState === 'loaded' && mostRecentAssistantTurn?.state === 'in-progress';
   }
 
+  function getConversationExists() {
+    /**
+     * If we don't have a snapshot yet, then we don't know if the conversation exists.
+     */
+    if (!snapshot || newConversationBeingCreatedButNoResponseTokensYet.current) {
+      return undefined;
+    }
+
+    return !snapshot.empty;
+  }
+
+  console.log('nth==', {
+    conversationExists: getConversationExists(),
+    loadState,
+    snapshotEmpty: snapshot?.empty,
+    newConversationBeingCreated: newConversationBeingCreatedButNoResponseTokensYet.current
+  })
+
   return {
     turns,
     loadState,
@@ -452,6 +481,6 @@ export function useFixie({
     modelResponseInProgress: getModelResponseInProgress(),
     setInput,
     sendMessage,
-    conversationExists: snapshot ? !snapshot.empty : undefined,
+    conversationExists: getConversationExists()
   };
 }

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -1,10 +1,8 @@
 import { getFirestore, collection, doc, query, orderBy, FirestoreError, onSnapshot } from 'firebase/firestore';
-// import { useCollectionData as typedUseCollectionData } from 'react-firebase-hooks/firestore';
-// import { useCollectionData as untypedUseCollectionData } from 'react-firebase-hooks/firestore/dist/index.esm.js';
 import { initializeApp } from 'firebase/app';
 
 import { useState, SetStateAction, Dispatch, useEffect } from 'react';
-import _, { set } from 'lodash';
+import _ from 'lodash';
 import {
   MessageGenerationParams,
   AgentId,
@@ -15,10 +13,6 @@ import {
 } from './sidekick-types.js';
 import { Jsonifiable } from 'type-fest';
 import { IsomorphicFixieClient } from './isomorphic-client.js';
-
-// This is whacky. I did it because Webpack from Fixie Frame threw an error
-// when trying to build this file. (Vite from Redwood worked fine.)
-// const useCollectionData = untypedUseCollectionData as typeof typedUseCollectionData;
 
 export interface UseFixieResult {
   /**

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -381,17 +381,19 @@ export class FixieConversationClient extends EventTarget {
     this.lastSeenMostRecentAgentTextMessage = '';
     this.modelResponseRequested = 'regenerate';
     this.dispatchStateChangeEvent();
-    const response = this.fixieClient.regenerate(
+    const requestStart = this.fixieClient.regenerate(
       agentId,
       this.conversationId,
       this.getMostRecentAssistantTurn()!.id,
       fullMessageGenerationParams
     );
-    response.then(() => {
-      this.modelResponseRequested = null;
-      this.dispatchStateChangeEvent();
-    });
-    return response;
+    requestStart
+      .then((response) => response.text())
+      .then(() => {
+        this.modelResponseRequested = null;
+        this.dispatchStateChangeEvent();
+      });
+    return requestStart;
   }
 
   public stop(agentId: AgentId) {
@@ -405,12 +407,14 @@ export class FixieConversationClient extends EventTarget {
       this.lastAssistantMessagesAtStop = mostRecentAssistantTurn.messages;
     }
     this.dispatchStateChangeEvent();
-    const response = this.fixieClient.stopGeneration(agentId, this.conversationId, mostRecentAssistantTurn!.id);
-    response.then(() => {
-      this.modelResponseRequested = null;
-      this.dispatchStateChangeEvent();
-    });
-    return response;
+    const requestStart = this.fixieClient.stopGeneration(agentId, this.conversationId, mostRecentAssistantTurn!.id);
+    requestStart
+      .then((response) => response.text())
+      .then(() => {
+        this.modelResponseRequested = null;
+        this.dispatchStateChangeEvent();
+      });
+    return requestStart;
   }
 
   private getMostRecentAssistantTurn() {
@@ -531,10 +535,8 @@ export function useFixie({
     let conversation: FixieConversationClient;
 
     function updateLocalStateFromConversation() {
-      console.log('useFixie updateLocalStateFromConversation');
       setLoadState(conversation.getLoadState());
       setTurns(conversation.getTurns());
-      console.log('useFixie turns', conversation.getTurns());
       setModelResponseInProgress(conversation.getModelResponseInProgress());
       setConversationExists(conversation.exists());
     }

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -292,6 +292,9 @@ class FixieConversationClient extends EventTarget {
   }
 
   public exists() {
+    if (this.loadState === 'loading' || this.loadState === 'no-conversation-set') {
+      return undefined;
+    }
     return this.isEmpty === false || this.optimisticallyExists;
   }
 
@@ -514,6 +517,7 @@ export function useFixie({
     let conversation: FixieConversationClient;
 
     function updateLocalStateFromConversation() {
+      console.log('useFixie updateLocalStateFromConversation')
       setLoadState(conversation.getLoadState());
       setTurns(conversation.getTurns());
       setModelResponseInProgress(conversation.getModelResponseInProgress());

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -14,6 +14,9 @@ import {
 import { Jsonifiable } from 'type-fest';
 import { IsomorphicFixieClient } from './isomorphic-client.js';
 
+/**
+ * The result of the useFixie hook.
+ */
 export interface UseFixieResult {
   /**
    * The conversation history.
@@ -75,6 +78,9 @@ export interface UseFixieResult {
   conversationExists?: boolean;
 }
 
+/**
+ * Arguments passed to the useFixie hook.
+ */
 export interface UseFixieArgs {
   /**
    * The ID of the conversation to use.
@@ -128,12 +134,20 @@ const firebaseConfig = {
 
 type ModelRequestedState = 'stop' | 'regenerate' | null;
 
+/**
+ * An event that will be fired when the model has emitted new tokens.
+ */
 export class NewTokensEvent extends Event {
   constructor(public readonly tokens: string) {
     super('newTokens');
   }
 }
 
+/**
+ * An event that will be emitted when there are perf traces to log.
+ * If you would like to log them, listen for this event, and use the `data` and `message` properties to log to whatever
+ * your monitoring system is.
+ */
 export class PerfLogEvent extends Event {
   // I think using `data` as a var name is fine here.
   /* eslint-disable-next-line id-blacklist */
@@ -142,6 +156,9 @@ export class PerfLogEvent extends Event {
   }
 }
 
+/**
+ * A client that maintains a connection to a particular conversation.
+ */
 export class FixieConversationClient extends EventTarget {
   // I think using `data` as a var name is fine here.
   /* eslint-disable id-blacklist */
@@ -411,6 +428,11 @@ export class FixieConversationClient extends EventTarget {
   }
 }
 
+/**
+ * A client that maintains a connection to the Fixie conversation API.
+ */
+// This may be of minimal value, and we should just consolidate into using FixieConversationClient directly. Maybe the
+// methods on this class should just be static methods on FixieConversationClient.
 export class FixieChatClient {
   private readonly conversationsRoot: ReturnType<typeof collection>;
   private readonly fixieClient: IsomorphicFixieClient;
@@ -443,6 +465,12 @@ export class FixieChatClient {
   }
 }
 
+/**
+ * A map of Fixie API URLs to FixieChatClients.
+ *
+ * In practice, this will only ever have a single entry. But the useFixie hook takes a fixieAPIUrl argument, so if we don't
+ * handle multiple possible values, it'll be a footgun.
+ */
 const fixieChatClients: Record<string, FixieChatClient> = {};
 
 /**

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -134,13 +134,13 @@ const firebaseConfig = {
 
 type ModelRequestedState = 'stop' | 'regenerate' | null;
 
-class NewTokensEvent extends Event {
+export class NewTokensEvent extends Event {
   constructor(public readonly tokens: string) {
     super('newTokens');
   }
 }
 
-class PerfLogEvent extends Event {
+export class PerfLogEvent extends Event {
   // I think using `data` as a var name is fine here.
   /* eslint-disable-next-line id-blacklist */
   constructor(public readonly message: string, public readonly data: object) {
@@ -148,7 +148,7 @@ class PerfLogEvent extends Event {
   }
 }
 
-class FixieConversationClient extends EventTarget {
+export class FixieConversationClient extends EventTarget {
   // I think using `data` as a var name is fine here.
   /* eslint-disable id-blacklist */
   private performanceTrace: { name: string; timeMs: number; data?: Jsonifiable }[] = [];
@@ -417,7 +417,7 @@ class FixieConversationClient extends EventTarget {
   }
 }
 
-class FixieChatClient {
+export class FixieChatClient {
   private readonly conversationsRoot: ReturnType<typeof collection>;
   private readonly fixieClient: IsomorphicFixieClient;
   private conversations: Record<ConversationId, FixieConversationClient> = {};
@@ -560,7 +560,7 @@ export function useFixie({
    */
   if (!conversationId) {
     return {
-      turns,
+      turns: conversationFixtures ?? turns,
       loadState,
       modelResponseInProgress,
       regenerate,
@@ -612,7 +612,7 @@ export function useFixie({
   }
 
   return {
-    turns,
+    turns: conversationFixtures ?? turns,
     loadState,
     input,
     error: undefined,

--- a/packages/fixie/src/use-fixie.ts
+++ b/packages/fixie/src/use-fixie.ts
@@ -155,11 +155,6 @@ export function useFixie({
   const [input, setInput] = useState('');
   const [conversationId, setConversationId] = useState(userPassedConversationId);
 
-  function handleNewConversationId(conversationId: ConversationId) {
-    setConversationId(conversationId);
-    onNewConversation?.(conversationId);
-  }
-
   useEffect(() => {
     setConversationId(userPassedConversationId);
   }, [userPassedConversationId]);
@@ -232,7 +227,8 @@ export function useFixie({
     const conversationId = (
       await fixieClient.startConversation(agentId, fullMessageGenerationParams, overriddenInput ?? input)
     ).conversationId;
-    handleNewConversationId(conversationId);
+    setConversationId(conversationId);
+    onNewConversation?.(conversationId);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -13077,7 +13077,6 @@ __metadata:
     open: ^9.1.0
     ora: ^7.0.1
     prettier: ^3.0.0
-    react-firebase-hooks: ^5.1.1
     terminal-kit: ^3.0.0
     type-fest: ^4.3.1
     typescript: 5.1.3
@@ -21543,16 +21542,6 @@ __metadata:
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
   checksum: 2071415b4f76a3e6b55c84611c4d24dcb12ffc85811a2840b5a3f1ff2d1a99be1020d9437ee7c6e024c9f4cbb84ceb35e48cf84f28fcb00265ad2dfdd3947704
-  languageName: node
-  linkType: hard
-
-"react-firebase-hooks@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "react-firebase-hooks@npm:5.1.1"
-  peerDependencies:
-    firebase: ">= 9.0.0"
-    react: ">= 16.8.0"
-  checksum: f7dbc42202082e35a4bbd60e6b729cf7a1a14ca300850f35dbcbda3fe3ecef0c1f8157c5dec711edfd3d6e021f2626e768241296598896731a56ce768bab829b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, all state lived in the `useFixie` hook. This was bad, because if the calling component unmounted, all the state would be lost. This led to flickering and an inability to reliably cache.

To solve this, we do the same thing libraries like react-query or Apollo do: have state live outside the hook itself. This allows the hook to simply be a shim to the React lifecycle.

This also provides an opening for other frameworks to integrate.

I'm completely confident this is an improvement in correctness over what we have today. There may be some minor issues, but there are also some backend issues right now, so it's a little hard to tell. I'm going to land this and we can keep testing with it.