### PR TITLE
Add support for inferring custom runtime parameters

### DIFF
--- a/packages/fixie-hello-world/src/index.tsx
+++ b/packages/fixie-hello-world/src/index.tsx
@@ -2,10 +2,16 @@ import { ChatCompletion, SystemMessage, ConversationHistory } from 'ai-jsx/core/
 
 console.log('Fixie Hello World agent starting.');
 
-export default function HelloWorld() {
+export default function HelloWorld({
+  character = 'Clippy from Microsoft Office',
+  temperature = 1,
+}: {
+  character?: string;
+  temperature?: number;
+}) {
   return (
-    <ChatCompletion temperature={1}>
-      <SystemMessage>You are Clippy from Microsoft Office. Respond to the user accordingly.</SystemMessage>
+    <ChatCompletion temperature={temperature}>
+      <SystemMessage>You are {character}. Respond to the user accordingly.</SystemMessage>
       <ConversationHistory />
     </ChatCompletion>
   );

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
@@ -37,6 +37,7 @@
     "ora": "^7.0.1",
     "react-firebase-hooks": "^5.1.1",
     "terminal-kit": "^3.0.0",
+    "typescript-json-schema": "^0.61.0",
     "untildify": "^5.0.0",
     "watcher": "^2.3.0"
   },

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -288,7 +288,7 @@ export class FixieAgent {
     );
     const program = TJS.programFromConfig(tsconfigPath, [tempPath]);
     const schema = TJS.generateSchema(program, 'RuntimeParameters', settings);
-    if (schema?.type !== 'object') {
+    if (schema && schema.type !== 'object') {
       throw new Error(`The first argument of your default export must be an object (not ${schema.type})`);
     }
 

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -267,7 +267,7 @@ export class FixieAgent {
     // with the runtime parameters for the agent.
     const tsconfigPath = path.resolve(path.join(agentPath, 'tsconfig.json'));
     if (!fs.existsSync(tsconfigPath)) {
-      term.yellow('⚠️ tsconfig.json not found. Your agent will not support runtime parameters.\n');
+      term.yellow(`⚠️ tsconfig.json not found at ${tsconfigPath}. Your agent will not support runtime parameters.\n`);
       return null;
     }
 
@@ -288,7 +288,7 @@ export class FixieAgent {
     );
     const program = TJS.programFromConfig(tsconfigPath, [tempPath]);
     const schema = TJS.generateSchema(program, 'RuntimeParameters', settings);
-    if (schema && schema.type !== 'object') {
+    if (schema?.type !== 'object') {
       throw new Error(`The first argument of your default export must be an object (not ${schema.type})`);
     }
 

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -10,6 +10,8 @@ import { execa } from 'execa';
 import Watcher from 'watcher';
 import net from 'node:net';
 
+import * as TJS from 'typescript-json-schema';
+
 const { terminal: term } = terminal;
 
 import { FixieClient } from './client.js';
@@ -260,6 +262,39 @@ export class FixieAgent {
     return config as AgentConfig;
   }
 
+  private static inferRuntimeParametersSchema(agentPath: string): TJS.Definition | null {
+    // If there's a tsconfig.json file, try to use Typescript to produce a JSON schema
+    // with the runtime parameters for the agent.
+    const tsconfigPath = path.resolve(path.join(agentPath, 'tsconfig.json'));
+    if (!fs.existsSync(tsconfigPath)) {
+      term.yellow('⚠️ tsconfig.json not found. Your agent will not support runtime parameters.\n');
+      return null;
+    }
+
+    const settings: TJS.PartialArgs = {
+      required: true,
+      noExtraProps: true,
+    };
+
+    // We're currently assuming the entrypoint is exported from src/index.{ts,tsx}.
+    const handlerPath = path.resolve(path.join(agentPath, 'src/index.js'));
+    const tempPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'fixie-')), 'extract-parameters-schema.mts');
+    fs.writeFileSync(
+      tempPath,
+      `
+      import Handler from '${handlerPath}';
+      export type RuntimeParameters = Parameters<typeof Handler>[0] extends infer T ? T : {};
+      `
+    );
+    const program = TJS.programFromConfig(tsconfigPath, [tempPath]);
+    const schema = TJS.generateSchema(program, 'RuntimeParameters', settings);
+    if (schema && schema.type !== 'object') {
+      throw new Error(`The first argument of your default export must be an object (not ${schema.type})`);
+    }
+
+    return schema;
+  }
+
   /** Package the code in the given directory and return the path to the tarball. */
   private static getCodePackage(agentPath: string): string {
     // Read the package.json file to get the package name and version.
@@ -279,7 +314,10 @@ export class FixieAgent {
 
   /** Create a new agent revision, which deploys the agent. */
   private async createRevision(
-    opts: MergeExclusive<{ externalUrl: string }, { tarball: string; environmentVariables: Record<string, string> }>
+    opts: MergeExclusive<{ externalUrl: string }, { tarball: string; environmentVariables: Record<string, string> }> & {
+      defaultRuntimeParameters?: Record<string, unknown> | null;
+      runtimeParametersSchema?: TJS.Definition | null;
+    }
   ): Promise<AgentRevision> {
     const uploadFile = opts.tarball ? fs.readFileSync(fs.realpathSync(opts.tarball)) : undefined;
 
@@ -291,6 +329,7 @@ export class FixieAgent {
           $makeCurrent: Boolean!
           $externalDeployment: ExternalDeploymentInput
           $managedDeployment: ManagedDeploymentInput
+          $defaultRuntimeParameters: JSONString
         ) {
           createAgentRevision(
             agentHandle: $handle
@@ -299,6 +338,7 @@ export class FixieAgent {
               metadata: $metadata
               externalDeployment: $externalDeployment
               managedDeployment: $managedDeployment
+              defaultRuntimeParameters: $defaultRuntimeParameters
             }
           ) {
             revision {
@@ -312,7 +352,11 @@ export class FixieAgent {
         handle: this.handle,
         metadata: [],
         makeCurrent: true,
-        externalDeployment: opts.externalUrl && { url: opts.externalUrl },
+        defaultRuntimeParameters: JSON.stringify(opts.defaultRuntimeParameters),
+        externalDeployment: opts.externalUrl && {
+          url: opts.externalUrl,
+          runtimeParametersSchema: JSON.stringify(opts.runtimeParametersSchema),
+        },
         managedDeployment: opts.tarball &&
           uploadFile && {
             codePackage: new Blob([uploadFile], { type: 'application/gzip' }),
@@ -320,6 +364,7 @@ export class FixieAgent {
               name: key,
               value,
             })),
+            runtimeParametersSchema: JSON.stringify(opts.runtimeParametersSchema),
           },
       },
       fetchPolicy: 'no-cache',
@@ -470,9 +515,10 @@ export class FixieAgent {
     }
 
     const agent = await this.ensureAgent(client, agentId, config);
+    const runtimeParametersSchema = this.inferRuntimeParametersSchema(agentPath);
     const tarball = FixieAgent.getCodePackage(agentPath);
     const spinner = ora(' 🚀 Deploying... (hang tight, this takes a minute or two!)').start();
-    const revision = await agent.createRevision({ tarball, environmentVariables });
+    const revision = await agent.createRevision({ tarball, environmentVariables, runtimeParametersSchema });
     spinner.succeed(`Agent ${config.handle} is running at: ${agent.agentUrl()}`);
     return revision;
   }
@@ -503,6 +549,12 @@ export class FixieAgent {
     if (!fs.existsSync(packageJsonPath)) {
       throw Error(`No package.json found in ${packageJsonPath}. Only JS-based agents are supported.`);
     }
+
+    // Infer the runtime parameters schema. We'll create a generator that yields whenever the schema changes.
+    let runtimeParametersSchema = FixieAgent.inferRuntimeParametersSchema(agentPath);
+    const { iterator: schemaGenerator, push: pushToSchemaGenerator } =
+      this.createAsyncIterable<TJS.Definition | null>();
+    pushToSchemaGenerator(runtimeParametersSchema);
 
     // Start the agent process locally.
     let agentProcess = FixieAgent.spawnAgentProcess(agentPath, port, environmentVariables);
@@ -540,116 +592,35 @@ export class FixieAgent {
           });
         }
       });
-      agentProcess = FixieAgent.spawnAgentProcess(agentPath, port, environmentVariables);
+
+      try {
+        const newSchema = FixieAgent.inferRuntimeParametersSchema(agentPath);
+        if (JSON.stringify(runtimeParametersSchema) !== JSON.stringify(newSchema)) {
+          pushToSchemaGenerator(newSchema);
+          runtimeParametersSchema = newSchema;
+        }
+
+        agentProcess = FixieAgent.spawnAgentProcess(agentPath, port, environmentVariables);
+      } catch (ex) {
+        term(`❌ Failed to restart agent process: ${ex} \n`);
+      }
     });
-
-    // Poll the port until it's listening.
-    async function waitForAgentToBeReady() {
-      while (true) {
-        try {
-          await new Promise<void>((resolve, reject) => {
-            const socket = net.connect({
-              host: '127.0.0.1',
-              port,
-            });
-
-            socket.on('connect', resolve);
-            socket.on('error', reject);
-          });
-          break;
-        } catch {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-      }
-    }
-
-    async function* spawnTunnel(port: number): AsyncGenerator<string> {
-      type AsyncGeneratorYield<T> = (value: T) => void;
-      // Represents the value yielded by the subprocess.
-      let yieldValue: AsyncGeneratorYield<string> | null = null;
-      // This Promise is resolved when the tunnel subprocess yields a new address.
-      let whenYielded = new Promise<string>((resolve) => {
-        yieldValue = resolve;
-      });
-
-      term('🚇 Starting tunnel process...\n');
-      // We use localhost.run as a tunneling service. This sets up an SSH tunnel
-      // to the provided local port via localhost.run. The subprocess returns a
-      // stream of JSON responses, one per line, with the external URL of the tunnel
-      // as it changes.
-      const subProcess = execa('ssh', [
-        '-R',
-        // N.B. 127.0.0.1 must be used on Windows (not localhost or 0.0.0.0)
-        `80:127.0.0.1:${port}`,
-        '-o',
-        // Need to send keepalives to prevent the connection from getting chopped
-        // (see https://localhost.run/docs/faq#my-connection-is-unstable-tunnels-go-down-often)
-        'ServerAliveInterval=59',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        'nokey@localhost.run',
-        '--',
-        '--output=json',
-      ]);
-      subProcess.stdout?.setEncoding('utf8');
-
-      // Every time the subprocess emits a new line, we parse it as JSON ans
-      // extract the 'address' field.
-      let currentLine = '';
-      subProcess.stdout?.on('data', (chunk: string) => {
-        // We need to do buffering since the data we get from stdout
-        // will not necessarily be line-buffered. We can get 0, 1, or more complete
-        // lines in a single chunk.
-        currentLine += chunk;
-        let newlineIndex;
-        while ((newlineIndex = currentLine.indexOf('\n')) !== -1) {
-          const line = currentLine.slice(0, newlineIndex);
-          currentLine = currentLine.slice(newlineIndex + 1);
-          // Parse data as JSON.
-          const pdata = JSON.parse(line);
-          // If pdata has the 'address' field, yield it.
-          if (pdata.address) {
-            yieldValue?.(`https://${pdata.address}`);
-          }
-        }
-      });
-      if (debug) {
-        subProcess.stderr?.on('data', (sdata: string) => {
-          console.error(`🚇 Tunnel stderr: ${sdata}`);
-        });
-        subProcess.on('close', (returnCode: number) => {
-          console.log(`🚇 Tunnel child process exited with code ${returnCode}`);
-        });
-      }
-      // Now we wait for the subprocess to yield a new address, which we then
-      // re-yield to the caller of this function.
-      while (true) {
-        const tunnelAddress = await whenYielded;
-        if (tunnelAddress === '') {
-          break;
-        }
-        yield tunnelAddress;
-        yieldValue = null;
-        whenYielded = new Promise<string>((resolve) => {
-          yieldValue = resolve;
-        });
-      }
-    }
 
     // This is an iterator which yields the public URL of the tunnel where the agent
     // can be reached by the Fixie service. The tunnel address can change over time.
-    let deploymentUrlsIter;
+    let deploymentUrlsIter: AsyncIterator<string>;
     if (tunnel) {
-      deploymentUrlsIter = spawnTunnel(port);
+      deploymentUrlsIter = FixieAgent.spawnTunnel(port, Boolean(debug));
     } else {
       if (!config.deploymentUrl) {
         throw Error('No deployment URL specified in agent.yaml');
       }
-      deploymentUrlsIter = [
-        (async function* () {
-          yield config.deploymentUrl;
-        })(),
-      ];
+      deploymentUrlsIter = (async function* () {
+        yield config.deploymentUrl as string;
+
+        // Never yield another value.
+        await new Promise(() => {});
+      })();
     }
 
     const agent = await this.ensureAgent(client, agentId, config);
@@ -684,8 +655,11 @@ export class FixieAgent {
 
     // The tunnel may yield different URLs over time. We need to create a new
     // agent revision each time.
-    for await (const currentUrl of deploymentUrlsIter) {
-      await waitForAgentToBeReady();
+    for await (const [currentUrl, runtimeParametersSchema] of this.zipAsyncIterables(
+      deploymentUrlsIter,
+      schemaGenerator
+    )) {
+      await FixieAgent.pollPortUntilReady(port);
 
       term('🚇 Current tunnel URL is: ').green(currentUrl)('\n');
       try {
@@ -694,7 +668,7 @@ export class FixieAgent {
           await agent.deleteRevision(currentRevision.id);
           currentRevision = null;
         }
-        currentRevision = await agent.createRevision({ externalUrl: currentUrl as string });
+        currentRevision = await agent.createRevision({ externalUrl: currentUrl, runtimeParametersSchema });
         term('🥡 Created temporary agent revision ').green(currentRevision.id)('\n');
         term('🥡 Agent ').green(config.handle)(' is running at: ').green(agent.agentUrl())('\n');
       } catch (e: any) {
@@ -703,5 +677,137 @@ export class FixieAgent {
         continue;
       }
     }
+  }
+
+  private static async pollPortUntilReady(port: number): Promise<void> {
+    while (true) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const socket = net.connect({
+            host: '127.0.0.1',
+            port,
+          });
+
+          socket.on('connect', resolve);
+          socket.on('error', reject);
+        });
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+  }
+
+  private static createAsyncIterable<T>(): { iterator: AsyncIterator<T>; push: (value: T) => void } {
+    let streamController: ReadableStreamDefaultController<T>;
+    const stream = new ReadableStream<T>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+
+    return {
+      // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62651
+      iterator: stream[Symbol.asyncIterator](),
+      push: (value: T) => {
+        streamController.enqueue(value);
+      },
+    };
+  }
+
+  private static async *zipAsyncIterables<T, U>(
+    gen1: AsyncIterator<T>,
+    gen2: AsyncIterator<U>
+  ): AsyncGenerator<[T, U]> {
+    const generators = [gen1, gen2] as const;
+    let currentValues = (await Promise.all(generators.map((g) => g.next()))).map((v) => v.value) as [T, U];
+    let nextPromises = generators.map((g) => g.next());
+
+    while (true) {
+      yield currentValues;
+
+      // Wait for one of the generators to yield a new value.
+      await Promise.race(nextPromises);
+
+      async function updateWithReadyValue(index: number): Promise<boolean> {
+        const value = await Promise.race([nextPromises[index], null]);
+        if (value === null) {
+          return false;
+        }
+
+        if (value.done) {
+          return true;
+        }
+
+        currentValues[index] = value.value;
+        nextPromises[index] = generators[index].next();
+        return false;
+      }
+
+      const shouldExit = await Promise.all([0, 1].map(updateWithReadyValue));
+      if (shouldExit.some((v) => v)) {
+        break;
+      }
+    }
+  }
+
+  private static spawnTunnel(port: number, debug: boolean): AsyncIterator<string> {
+    const { iterator, push: pushToIterator } = this.createAsyncIterable<string>();
+
+    term('🚇 Starting tunnel process...\n');
+    // We use localhost.run as a tunneling service. This sets up an SSH tunnel
+    // to the provided local port via localhost.run. The subprocess returns a
+    // stream of JSON responses, one per line, with the external URL of the tunnel
+    // as it changes.
+    const subProcess = execa('ssh', [
+      '-R',
+      // N.B. 127.0.0.1 must be used on Windows (not localhost or 0.0.0.0)
+      `80:127.0.0.1:${port}`,
+      '-o',
+      // Need to send keepalives to prevent the connection from getting chopped
+      // (see https://localhost.run/docs/faq#my-connection-is-unstable-tunnels-go-down-often)
+      'ServerAliveInterval=59',
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      'nokey@localhost.run',
+      '--',
+      '--output=json',
+    ]);
+    subProcess.stdout?.setEncoding('utf8');
+
+    // Every time the subprocess emits a new line, we parse it as JSON ans
+    // extract the 'address' field.
+    let currentLine = '';
+    subProcess.stdout?.on('data', (chunk: string) => {
+      // We need to do buffering since the data we get from stdout
+      // will not necessarily be line-buffered. We can get 0, 1, or more complete
+      // lines in a single chunk.
+      currentLine += chunk;
+      let newlineIndex;
+      while ((newlineIndex = currentLine.indexOf('\n')) !== -1) {
+        const line = currentLine.slice(0, newlineIndex);
+        currentLine = currentLine.slice(newlineIndex + 1);
+        // Parse data as JSON.
+        const pdata = JSON.parse(line);
+        // If pdata has the 'address' field, yield it.
+        if (pdata.address) {
+          pushToIterator(`https://${pdata.address}`);
+        }
+      }
+    });
+
+    subProcess.stderr?.on('data', (sdata: string) => {
+      if (debug) {
+        console.error(`🚇 Tunnel stderr: ${sdata}`);
+      }
+    });
+    subProcess.on('close', (returnCode: number) => {
+      if (debug) {
+        console.log(`🚇 Tunnel child process exited with code ${returnCode}`);
+      }
+      iterator.return?.(null);
+    });
+
+    return iterator;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6581,6 +6581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^16.9.2":
+  version: 16.18.55
+  resolution: "@types/node@npm:16.18.55"
+  checksum: 6f5fca0063515545203ef7a1d587dd88f57bb15d88e053396648642dfce77cdd7ebf5312494a078c3ee27c0e62b599315e929086240e09f8ed0e8a84c20857a1
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^17.0.5":
   version: 17.0.45
   resolution: "@types/node@npm:17.0.45"
@@ -13081,6 +13088,7 @@ __metadata:
     terminal-kit: ^3.0.0
     type-fest: ^4.3.1
     typescript: 5.1.3
+    typescript-json-schema: ^0.61.0
     untildify: ^5.0.0
     watcher: ^2.3.0
   peerDependencies:
@@ -13547,7 +13555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -19827,6 +19835,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-equal@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "path-equal@npm:1.2.5"
+  checksum: 2bef7bcb98c7ae371c52c1562b2fc515bfd03bc1a5571df9a8591038db8d742ba2d1ff39aa5130853e6afb69e773ccba5095f54d2e6d17422ca03ef9047992d7
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -22539,7 +22554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-stable-stringify@npm:^2.3.1":
+"safe-stable-stringify@npm:^2.2.0, safe-stable-stringify@npm:^2.3.1":
   version: 2.4.3
   resolution: "safe-stable-stringify@npm:2.4.3"
   checksum: 3aeb64449706ee1f5ad2459fc99648b131d48e7a1fbb608d7c628020177512dc9d94108a5cb61bbc953985d313d0afea6566d243237743e02870490afef04b43
@@ -24804,6 +24819,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-json-schema@npm:^0.61.0":
+  version: 0.61.0
+  resolution: "typescript-json-schema@npm:0.61.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@types/node": ^16.9.2
+    glob: ^7.1.7
+    path-equal: ^1.2.5
+    safe-stable-stringify: ^2.2.0
+    ts-node: ^10.9.1
+    typescript: ~5.1.0
+    yargs: ^17.1.1
+  bin:
+    typescript-json-schema: bin/typescript-json-schema
+  checksum: 8359d5ca8ebcb96dca9cd968b46ea21da40a92ee872a44a7b5c6c8f8f4cd1ffbd0ea457752f3be7d44379ea286ccfaee1d40ab1810321ee45d0ecece80ed45ed
+  languageName: node
+  linkType: hard
+
 "typescript@npm:5.1.3, typescript@npm:^5.1.3":
   version: 5.1.3
   resolution: "typescript@npm:5.1.3"
@@ -24814,6 +24847,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:~5.1.0":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@5.1.3#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
   version: 5.1.3
   resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
@@ -24821,6 +24864,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 6f0a9dca6bf4ce9dcaf4e282aade55ef4c56ecb5fb98d0a4a5c0113398815aea66d871b5611e83353e5953a19ed9ef103cf5a76ac0f276d550d1e7cd5344f61e
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~5.1.0#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
   languageName: node
   linkType: hard
 
@@ -26420,7 +26473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.7.2":
+"yargs@npm:^17.1.1, yargs@npm:^17.3.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
This adds CLI support for inferring/setting the schema for custom runtime parameters. We use `typescript-json-schema` to infer the schema and set it in GraphQL. (This change does not add CLI support for setting default runtime parameters, but adds it to the underlying GraphQL mutation.)

The bulk of the change consists of refactoring `fixie serve` so that _either_ a tunnel URL change or parameter schema change triggers a new revision.