### PR TITLE
Remove extra initial whitespace

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -235,7 +235,6 @@ function RepairMdx({ children }: { children: string }) {
 }
 
 async function* LimitToValidMdx({ children }: { children: AI.Node }, { render, logger }: AI.ComponentContext) {
-  yield ' ';
   const rendered = render(children);
   for await (const frame of rendered) {
     const mdxCompileError = await getMdxCompileError(frame);

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.21.1
+## 0.21.2
+
+- Fix a bug in `LimitToValidMdx` where a whitespace character was initially yieled.
+
+## [0.21.1](https://github.com/fixie-ai/ai-jsx/commit/e6064f54fe253e3b8e182fa4f7e05fd37da15dbc)
 
 - `Sidekick` now accepts a `useCitationCard` prop, which controls whether it will emit `<Citation />` MDX components.
 

--- a/packages/sidekick-github/package.json
+++ b/packages/sidekick-github/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@fixieai/sdk": "*",
     "@tsconfig/node18": "^2.0.1",
+    "fixie": "*",
     "typescript": "^5.1.3"
   },
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23112,6 +23112,7 @@ __metadata:
     "@tsconfig/node18": ^2.0.1
     "@types/node": ^20.8.2
     ai-jsx: "*"
+    fixie: "*"
     typescript: ^5.1.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`LimitToValidMdx` yielded an initial single whitespace character, but there's no reason to do so. This removes it.