### PR TITLE
Remove (now-unsupported) generationParams

### DIFF
--- a/packages/docs/docs/sidekicks/sidekicks-quickstart.md
+++ b/packages/docs/docs/sidekicks/sidekicks-quickstart.md
@@ -199,7 +199,7 @@ You should see a stream of response messages from the Sidekick, as it sends back
 a response to your question. The last line of the response will show:
 
 ```
-{"id": "7a1c57c1-4068-4668-8878-ede11bcb81d6", "turns": [{"id": "8c747526-ac3c-45d2-94d6-c637993e7759", "timestamp": "2023-09-23T21:47:40.956489", "role": "user", "messages": [{"kind": "text", "content": "Tell me about yourself"}], "generationParams": null, "state": "done"}, {"id": "bc716f1b-8eba-4f4f-8df0-4a078fd8359e", "timestamp": "2023-09-23T21:47:41.267027+00:00", "role": "assistant", "messages": [{"kind": "text", "content": "Sure, I'm an AI assistant designed to help you with Git and GitHub."}], "generationParams": null, "state": "done", "inReplyToId": "8c747526-ac3c-45d2-94d6-c637993e7759"}]}
+{"id": "7a1c57c1-4068-4668-8878-ede11bcb81d6", "turns": [{"id": "8c747526-ac3c-45d2-94d6-c637993e7759", "timestamp": "2023-09-23T21:47:40.956489", "role": "user", "messages": [{"kind": "text", "content": "Tell me about yourself"}], "state": "done"}, {"id": "bc716f1b-8eba-4f4f-8df0-4a078fd8359e", "timestamp": "2023-09-23T21:47:41.267027+00:00", "role": "assistant", "messages": [{"kind": "text", "content": "Sure, I'm an AI assistant designed to help you with Git and GitHub."}], "state": "done", "inReplyToId": "8c747526-ac3c-45d2-94d6-c637993e7759"}]}
 ```
 
 It's a little ugly, of course, but if you pipe the output to `jq`, you can see a nicely-formatted
@@ -219,7 +219,6 @@ JSON object:
           "content": "Tell me about yourself"
         }
       ],
-      "generationParams": null,
       "state": "done"
     },
     {
@@ -232,7 +231,6 @@ JSON object:
           "content": "Sure, I'm an AI assistant designed to help you with Git and GitHub."
         }
       ],
-      "generationParams": null,
       "state": "done",
       "inReplyToId": "ef865d96-73c9-421a-9651-fee15ed23528"
     }

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/types.ts
+++ b/packages/fixie-sdk/src/types.ts
@@ -28,24 +28,16 @@ export interface ConversationTurn {
   id: string;
   timestamp: string;
   role: 'user' | 'assistant';
-  generationParams?: GenerationParams | null;
   messages: Message[];
   state: 'in-progress' | 'done' | 'stopped' | 'error';
   metadata?: Record<string, string | number | boolean | object | null> | null;
   errorDetail?: string | null;
 }
 
-export interface GenerationParams {
-  userTimeZoneOffset?: number | null;
-  model?: string | null;
-  modelProvider?: string | null;
-}
-
 export interface InvokeAgentRequest {
   conversationId: string;
   replyToTurnId?: string;
   conversation?: Conversation;
-  generationParams?: GenerationParams;
   parameters?: Record<string, Jsonifiable>;
 }
 

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "1.9.5",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/isomorphic-client.ts
+++ b/packages/fixie/src/isomorphic-client.ts
@@ -1,5 +1,5 @@
 import type { Jsonifiable } from 'type-fest';
-import { AgentId, ConversationId, MessageGenerationParams, MessageRequestParams } from './sidekick-types.js';
+import { AgentId, ConversationId, MessageRequestParams } from './sidekick-types.js';
 
 export interface UserInfo {
   id: number;
@@ -298,16 +298,11 @@ export class IsomorphicFixieClient {
    * @see stopGeneration
    * @see regenerate
    */
-  async startConversation(agentId: AgentId, generationParams: MessageGenerationParams, message?: string) {
+  async startConversation(agentId: AgentId, message?: string) {
     const abortController = new AbortController();
     const signal = abortController.signal;
 
-    const conversation = await this.request(
-      `/api/v1/agents/${agentId}/conversations`,
-      { generationParams, message },
-      'POST',
-      { signal }
-    );
+    const conversation = await this.request(`/api/v1/agents/${agentId}/conversations`, { message }, 'POST', { signal });
     if (!conversation.body) {
       throw new Error('Request to start a new conversation was empty');
     }
@@ -382,14 +377,11 @@ export class IsomorphicFixieClient {
    *            Stream entry 1: text: hello world I am
    *            Stream entry 2: text: hello world
    */
-  regenerate(
-    agentId: AgentId,
-    conversationId: ConversationId,
-    messageId: string,
-    messageGenerationParams: MessageGenerationParams
-  ) {
-    return this.request(`/api/v1/agents/${agentId}/conversations/${conversationId}/messages/${messageId}/regenerate`, {
-      generationParams: messageGenerationParams,
-    });
+  regenerate(agentId: AgentId, conversationId: ConversationId, messageId: string) {
+    return this.request(
+      `/api/v1/agents/${agentId}/conversations/${conversationId}/messages/${messageId}/regenerate`,
+      undefined,
+      'POST'
+    );
   }
 }

--- a/packages/fixie/src/sidekick-types.ts
+++ b/packages/fixie/src/sidekick-types.ts
@@ -1,18 +1,11 @@
 import { Jsonifiable } from 'type-fest';
 
-export type MessageGenerationParams = Partial<{
-  modelProvider: string | null;
-  model: string | null;
-  userTimeZoneOffset: number;
-}>;
-
 export type AgentId = string;
 export type ConversationId = string;
 export type Metadata = Record<string, Jsonifiable | undefined>;
 export interface MessageRequestParams {
   message: string;
   metadata?: Metadata;
-  generationParams: MessageGenerationParams | null;
 }
 
 export interface BaseConversationTurn<Role extends string> {
@@ -58,8 +51,6 @@ export interface AssistantConversationTurn extends UserOrAssistantConversationTu
    * The user turn that this turn was a reply to.
    */
   inReplyToId: string;
-
-  generationParams: MessageGenerationParams | null;
 }
 
 export interface UserConversationTurn extends UserOrAssistantConversationTurn<'user'> {}


### PR DESCRIPTION
Support for `generationParams` has been removed in favor of runtime-specific parameters.