### PR TITLE
Add export type to support isolatedModules

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/web.ts
+++ b/packages/fixie/web.ts
@@ -4,6 +4,6 @@ export {
   FloatingFixieEmbed,
   ControlledFloatingFixieEmbed,
   getBaseIframeProps,
-  FixieEmbedProps,
+  type FixieEmbedProps,
 } from './src/fixie-embed.js';
 export * from './src/use-fixie.js';


### PR DESCRIPTION
Change an export from `fixie/web` to be an explicit `export type` so that it can be used in contexts that enabled [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules).