### PR TITLE
Clean up trace roots in @fixieai/sdk

### DIFF
--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -7,12 +7,12 @@ import { hideBin } from 'yargs/helpers';
 import { fastify } from 'fastify';
 import { Readable } from 'stream';
 import { createRenderContext, Component } from 'ai-jsx';
-import { FixieAPIContext } from 'ai-jsx/batteries/fixie';
 import { InvokeAgentRequest } from './types.js';
-import { FixieRequestWrapper, RequestContext } from './request-wrapper.js';
+import { FixieRequestWrapper } from './request-wrapper.js';
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import path from 'path';
+import { debugRepresentation } from 'ai-jsx/core/debug';
 
 async function serve({
   packagePath,
@@ -61,15 +61,15 @@ async function serve({
     try {
       const invokeAgentRequest = req.body as InvokeAgentRequest;
       const renderable = (
-        <FixieAPIContext.Provider value={{ url: fixieApiUrl, authToken: (req as any).fixieAuthToken }}>
-          <RequestContext.Provider
-            value={{ request: invokeAgentRequest, agentId: (req as any).fixieVerifiedToken.payload.aid }}
-          >
-            <FixieRequestWrapper>
-              <Handler {...(invokeAgentRequest.parameters ?? {})} />
-            </FixieRequestWrapper>
-          </RequestContext.Provider>
-        </FixieAPIContext.Provider>
+        <FixieRequestWrapper
+          request={invokeAgentRequest}
+          fixieApiUrl={fixieApiUrl}
+          fixieAuthToken={(req as any).fixieAuthToken}
+          agentId={(req as any).fixieVerifiedToken.payload.aid}
+          {...debugRepresentation((e) => e.props.children)}
+        >
+          <Handler {...(invokeAgentRequest.parameters ?? {})} />
+        </FixieRequestWrapper>
       );
       const generator = createRenderContext({ enableOpenTelemetry: true }).render(renderable)[Symbol.asyncIterator]();
       return res

--- a/packages/fixie-sdk/src/types.ts
+++ b/packages/fixie-sdk/src/types.ts
@@ -36,6 +36,7 @@ export interface ConversationTurn {
 
 export interface InvokeAgentRequest {
   conversationId: string;
+  turnId: string;
   replyToTurnId?: string;
   conversation?: Conversation;
   parameters?: Record<string, Jsonifiable>;


### PR DESCRIPTION
This makes the `FixieRequestWrapper` the top-level renderable for Fixie agent requests structure the OpenTelemetry traces in a more straightforward way.

In particular, that component now sets a few semantic `ai.fixie.*` span attributes that allows the trace to be related to a specific span.