### PR TITLE
Make fixie client SDK UUID-safe

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/fixie-embed.tsx
+++ b/packages/fixie/src/fixie-embed.tsx
@@ -53,7 +53,7 @@ export interface FixieEmbedProps extends React.IframeHTMLAttributes<HTMLIFrameEl
   fixieHost?: string;
 }
 
-const defaultFixieHost = 'https://fixie.vercel.app';
+const defaultFixieHost = 'https://embed.fixie.ai';
 
 /**
  * A component to embed the Generic Fixie Chat UI on your page.
@@ -200,7 +200,10 @@ export function getBaseIframeProps({
   FixieEmbedProps,
   'speak' | 'debug' | 'fixieHost' | 'agentId' | 'agentSendsGreeting' | 'chatTitle' | 'primaryColor'
 >) {
-  const embedUrl = new URL(`/embed/${agentId}`, fixieHost ?? defaultFixieHost);
+  const embedUrl = new URL(
+    agentId.includes('/') ? `/embed/${agentId}` : `/agents/${agentId}`,
+    fixieHost ?? defaultFixieHost
+  );
   if (speak) {
     embedUrl.searchParams.set('speak', '1');
   }


### PR DESCRIPTION
This changes the `fixie` CLI to make it agnostic to whether the agent ID is specified as a UUID or owner/handle. Additionally:
- Fix `update` to block on the update before refetching
- Generate correct URLs for non-default Fixie API hosts