### PR TITLE
Fix baggage propagation on Linux, add severityNumber

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/log.ts
+++ b/packages/ai-jsx/src/core/log.ts
@@ -129,6 +129,15 @@ export class OpenTelemetryLogger extends LogImplementation {
   ): void {
     this.logger.emit({
       severityText: level.toUpperCase(),
+      severityNumber: {
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
+        trace: 1,
+        debug: 5,
+        info: 9,
+        warn: 13,
+        error: 17,
+        fatal: 21,
+      }[level],
       body: typeof metadataOrMessage === 'object' ? message ?? '' : metadataOrMessage,
       attributes: {
         element: `<${element.tag.name}>`,

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.21.2
+# 0.22.1
+
+- In the OpenTelemetry logger, ensure that SeverityNumber is set.
+
+## [0.22.0](https://github.com/fixie-ai/ai-jsx/commit/b5337176cd0d50c1691c2ae4bcc02e71a37b407c)
+
+- In the `Sidekick` component:
+  - Put the user system messages before the built-in system messages.
+  - Make the MDX formatting logic is conditional on using MDX
+  - Accept `children` as the conversation to act on (defaults to `<ConversationHistory>`)
+
+## [0.21.2](https://github.com/fixie-ai/ai-jsx/commit/f59cd9990d9f64f94dc961dd0308f0c0eca44e00)
 
 - Fix a bug in `LimitToValidMdx` where a whitespace character was initially yieled.
 

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/instrument.ts
+++ b/packages/fixie-sdk/src/instrument.ts
@@ -4,7 +4,7 @@ import fastify_instrumentation from '@opentelemetry/instrumentation-fastify';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
-import { BatchLogRecordProcessor, LogRecord } from '@opentelemetry/sdk-logs';
+import { BatchLogRecordProcessor, LogRecord, LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { Context, propagation } from '@opentelemetry/api';
 import { BatchSpanProcessor, Span } from '@opentelemetry/sdk-trace-base';
 
@@ -31,23 +31,35 @@ class CustomSpanProcessor extends BatchSpanProcessor {
   }
 }
 
-class CustomLogProcessor extends BatchLogRecordProcessor {
-  onEmit(logRecord: LogRecord): void {
-    // Attach any Fixie baggage to the log record.
-    const baggage = propagation.getActiveBaggage();
-    baggage?.getAllEntries().forEach(([key, value]) => {
-      if (key.startsWith('ai.fixie.')) {
-        logRecord.attributes[key] = value.value;
-      }
-    });
+class CustomLogProcessor implements LogRecordProcessor {
+  // N.B. Wraps (rather than extends) BatchLogRecordProcessor so that we can access
+  // the second argument of `onEmit` to access baggage.
+  constructor(private readonly delegated: LogRecordProcessor) {}
 
-    super.onEmit(logRecord);
+  forceFlush(): Promise<void> {
+    return this.delegated.forceFlush();
+  }
+  shutdown(): Promise<void> {
+    return this.delegated.shutdown();
+  }
+  onEmit(logRecord: LogRecord, context?: Context | undefined): void {
+    // Attach any Fixie baggage to the log record.
+    if (context) {
+      const baggage = propagation.getBaggage(context);
+      baggage?.getAllEntries().forEach(([key, value]) => {
+        if (key.startsWith('ai.fixie.')) {
+          logRecord.attributes[key] = value.value;
+        }
+      });
+    }
+
+    this.delegated.onEmit(logRecord);
   }
 }
 
 const sdk = new NodeSDK({
   spanProcessor: new CustomSpanProcessor(new OTLPTraceExporter()),
-  logRecordProcessor: new CustomLogProcessor(new OTLPLogExporter()),
+  logRecordProcessor: new CustomLogProcessor(new BatchLogRecordProcessor(new OTLPLogExporter())),
   instrumentations: [
     new HttpInstrumentation(),
     new fastify_instrumentation.FastifyInstrumentation(),


### PR DESCRIPTION
Empirically on Linux (but not on macOS) context is not active when the log record processor runs. This reworks the custom process so that context can be accessed explicitly.

Additionally, update the OpenTelemetry logger to set `severityNumber`.