### PR TITLE
TTS: orphan cancelled requests, reconnect websocket when needed

### DIFF
--- a/packages/ai-jsx/src/lib/tts/tts.tsx
+++ b/packages/ai-jsx/src/lib/tts/tts.tsx
@@ -976,6 +976,9 @@ export abstract class WebSocketTextToSpeech extends WebAudioTextToSpeech {
   private pendingText: string = '';
   constructor(name: string, private readonly url: string, public readonly voice: string) {
     super(name);
+    this.warmup();
+  }
+  warmup() {
     this.ensureSocket();
   }
   protected generate(text: string) {

--- a/packages/ai-jsx/src/lib/tts/tts.tsx
+++ b/packages/ai-jsx/src/lib/tts/tts.tsx
@@ -856,6 +856,8 @@ export class RestTextToSpeech extends WebAudioTextToSpeech {
     const reader = res.body!.getReader();
     while (true) {
       const { value, done } = await reader.read();
+      // eslint seems to think req.cancelled must be false, perhaps due to the earlier check.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (req.cancelled) {
         return;
       }


### PR DESCRIPTION
This avoids two issues:
- first, we would still send and download requests even after calling `tts.stop()`, which would lead to errors when calling `outputManager.appendBuffer` for a stream that no longer existed. This now cancels all requests on stop().
- second, if a websocket closed due to idling, the TTS object would be dead at that point. Now, we force a reconnect if the WS is closed (which will have extra latency, which can be avoided using the new `warmup()` method if we know a generation is imminent).