### PR TITLE
Add basic logs API support.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -48,6 +48,15 @@ export interface AgentRevision {
   created: Date;
 }
 
+/** Represents an Agent Log entry. */
+export interface AgentLogEntry {
+  timestamp: Date;
+  traceId?: string;
+  spanId?: string;
+  severity?: number;
+  message?: string;
+}
+
 /**
  * This class provides an interface to the Fixie Agent API.
  */
@@ -248,6 +257,17 @@ export class FixieAgent {
       },
     });
     this.metadata = await FixieAgent.getAgentById(this.client, this.agentId);
+  }
+
+  /** Return logs for this Agent. Returns the last 15 minutes of agent logs. */
+  async getLogs(): Promise<AgentLogEntry[]> {
+    // TODO: Expand parameters here to specify start/end times, deal with pagination, etc.
+    const retval = await this.client.request(`/api/v1/agents/${this.metadata.uuid}/logs`);
+    if (retval.status !== 200) {
+      return [];
+    }
+    const logs = (await retval.json()) as { logs: AgentLogEntry[] };
+    return logs.logs;
   }
 
   /** Load an agent configuration from the given directory. */

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -502,6 +502,17 @@ agent
     )
   );
 
+agent
+  .command('logs <agentId>')
+  .description('Fetch agent logs.')
+  .action(
+    catchErrors(async (agentId: string) => {
+      const client = await AuthenticateOrLogIn({ apiUrl: program.opts().url });
+      const result = await FixieAgent.GetAgent(client, agentId);
+      showResult(await result.getLogs(), program.opts().raw);
+    })
+  );
+
 registerDeployCommand(agent);
 registerServeCommand(agent);
 


### PR DESCRIPTION
This is SUPER basic but at least lets me fetch logs from the CLI. We can expand on it later. Also makes it possible to expose logs to the UI without having to write custom fetch code there.
