### PR TITLE
Remove FixieAgent export

### DIFF
--- a/packages/fixie/index.ts
+++ b/packages/fixie/index.ts
@@ -1,4 +1,3 @@
-export { FixieAgent } from './src/agent.js';
 export { FixieClient } from './src/client.js';
 export { IsomorphicFixieClient } from './src/isomorphic-client.js';
 export * from './src/sidekick-types.js';

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie/web.ts
+++ b/packages/fixie/web.ts
@@ -5,5 +5,4 @@ export {
   ControlledFloatingFixieEmbed,
   getBaseIframeProps,
 } from './src/fixie-embed.js';
-export { FixieAgent } from './src/agent.js';
 export * from './src/use-fixie.js';


### PR DESCRIPTION
`agent.ts` contains CLI command implementation and shouldn't be coded against. (In particular, it can't be imported in web contexts at all.)