### PR TITLE
Clean up exports from `fixie` package.

### DIFF
--- a/packages/fixie/index.ts
+++ b/packages/fixie/index.ts
@@ -1,3 +1,0 @@
-export { FixieClient } from './src/client.js';
-export { IsomorphicFixieClient } from './src/isomorphic-client.js';
-export * from './src/sidekick-types.js';

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,14 +1,17 @@
 {
   "name": "fixie",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://fixie.ai",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "start": "node --no-warnings src/main.js",
+    "start": "node --no-warnings dist/main.js",
     "build-start": "yarn run build && yarn run start",
     "format": "prettier --write .",
     "test": "yarn run build && yarn run lint",
@@ -19,7 +22,13 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "bin": "./src/main.js",
+  "bin": "./dist/main.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./web": "./dist/web.js"
+  },
   "dependencies": {
     "@apollo/client": "^3.8.1",
     "@types/apollo-upload-client": "^17.0.2",

--- a/packages/fixie/src/index.ts
+++ b/packages/fixie/src/index.ts
@@ -1,3 +1,4 @@
 export { FixieClient } from './client.js';
 export { IsomorphicFixieClient } from './isomorphic-client.js';
+export { FixieAgent } from './agent.js';
 export * from './sidekick-types.js';

--- a/packages/fixie/src/index.ts
+++ b/packages/fixie/src/index.ts
@@ -1,0 +1,3 @@
+export { FixieClient } from './client.js';
+export { IsomorphicFixieClient } from './isomorphic-client.js';
+export * from './sidekick-types.js';

--- a/packages/fixie/src/web.ts
+++ b/packages/fixie/src/web.ts
@@ -1,0 +1,8 @@
+export { IsomorphicFixieClient } from './isomorphic-client.js';
+export {
+  InlineFixieEmbed,
+  FloatingFixieEmbed,
+  ControlledFloatingFixieEmbed,
+  getBaseIframeProps,
+} from './fixie-embed.js';
+export * from './use-fixie.js';

--- a/packages/fixie/tsconfig.json
+++ b/packages/fixie/tsconfig.json
@@ -9,10 +9,10 @@
     "moduleResolution": "node16",
     "jsx": "react",
     "esModuleInterop": true,
-    "outDir": ".",
+    "outDir": "dist",
     "declaration": true,
     "lib": ["dom", "dom.iterable", "ES2022"]
   },
-  "include": ["src/*", "jest.config.ts", ".eslintrc.cjs", "index.ts", "web.ts"],
+  "include": ["src/*", ".eslintrc.cjs"],
   "exclude": []
 }

--- a/packages/fixie/web.ts
+++ b/packages/fixie/web.ts
@@ -1,8 +1,0 @@
-export { IsomorphicFixieClient } from './src/isomorphic-client.js';
-export {
-  InlineFixieEmbed,
-  FloatingFixieEmbed,
-  ControlledFloatingFixieEmbed,
-  getBaseIframeProps,
-} from './src/fixie-embed.js';
-export * from './src/use-fixie.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12810,7 +12810,7 @@ __metadata:
     react-dom:
       optional: true
   bin:
-    fixie: ./src/main.js
+    fixie: ./dist/main.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Export `FixieAgent` from the `fixie` package, move all source files under `src/`, and build to `dist/`. 