### PR TITLE
Fix turbo outputs for fixie/docs packages

### DIFF
--- a/packages/docs/turbo.json
+++ b/packages/docs/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": ["build/**", "docs/api/**"]
+    }
+  }
+}

--- a/packages/fixie/turbo.json
+++ b/packages/fixie/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": ["*.js", "*.d.ts", "src/**/*.js", "src/**/*.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
The monorepo-level turbo `"outputs"` key for build didn't capture the `fixie` or `docs` build outputs.

This could cause intermittent build failures (such as the one currently plaguing CI).