### PR TITLE
Update part1-completion.md (bad link)

### DIFF
--- a/packages/docs/docs/tutorials/aijsxTutorials/part1-completion.md
+++ b/packages/docs/docs/tutorials/aijsxTutorials/part1-completion.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 In this tutorial, we're going to introduce the basic concepts of AI.JSX one step at
 a time. All of the code for these tutorials can be found on GitHub at
-https://github.com/fixie-ai/ai-jsx/tree/main/packages/tutorial.
+https://github.com/fixie-ai/ai-jsx/blob/main/packages/tutorial.
 
 Let's start with the basic "hello world" example for AI.JSX,
 which invokes a Large Language Model with a fixed prompt, and


### PR DESCRIPTION
A quick, update: the link `https://github.com/fixie-ai/ai-jsx/tree/main/packages/tutorial` in the document `https://docs.ai-jsx.com/tutorials/aijsxTutorials/part1-completion` is bad