### PR TITLE
Add support for OpenAI parallel function calls

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "volta": {
     "extends": "../../package.json"
   },
@@ -391,7 +391,7 @@
     "lodash": "^4.17.21",
     "ml-distance": "^4.0.1",
     "mpg123-decoder": "^0.4.9",
-    "openai": "^4.1.0",
+    "openai": "^4.16.0",
     "pino": "^8.14.1",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -39,7 +39,9 @@ export function getShrinkableConversation(messages: ConversationMessage[], fullC
             importance={0}
             replacement={
               <Shrinkable importance={messageIndex + 1}>
-                <FunctionResponse name={message.element.props.name}>[snip...]</FunctionResponse>
+                <FunctionResponse id={message.element.props.id} name={message.element.props.name}>
+                  [snip...]
+                </FunctionResponse>
               </Shrinkable>
             }
           >
@@ -93,25 +95,38 @@ export function getNextConversationStep(
 
   switch (lastMessage.type) {
     case 'functionCall': {
-      const { name, args } = lastMessage.element.props;
-      const executedFunction = (
-        <ExecuteFunction
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          func={updatedTools[name]?.func}
-          name={name}
-          args={args}
-        />
-      );
-      // If we are using a tool based on redacted functions, we don't want to redact it further
-      if (tools && !(name in tools)) {
-        return executedFunction;
-      }
-      // Function responses can potentially be very large. In that case, we need
-      // some way of handling that so the context window doesn't blow up.
-      return (
-        <LargeFunctionResponseWrapper numChunks={10} maxLength={10500} failedMaxLength={4000}>
-          {executedFunction}
-        </LargeFunctionResponseWrapper>
+      // Collect all the adjacent function calls and execute them.
+      const functionCalls = _.takeRightWhile(messages, (m) => m.type === 'functionCall') as (ConversationMessage & {
+        type: 'functionCall';
+      })[];
+
+      return functionCalls.map(
+        ({
+          element: {
+            props: { id, name, args },
+          },
+        }) => {
+          const executedFunction = (
+            <ExecuteFunction
+              id={id}
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              func={updatedTools[name]?.func}
+              name={name}
+              args={args}
+            />
+          );
+          // If we are using a tool based on redacted functions, we don't want to redact it further
+          if (tools && !(name in tools)) {
+            return executedFunction;
+          }
+          // Function responses can potentially be very large. In that case, we need
+          // some way of handling that so the context window doesn't blow up.
+          return (
+            <LargeFunctionResponseWrapper numChunks={10} maxLength={10500} failedMaxLength={4000}>
+              {executedFunction}
+            </LargeFunctionResponseWrapper>
+          );
+        }
       );
     }
     /**

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -284,7 +284,6 @@ async function* LimitToValidMdx({ children }: { children: AI.Node }, { render, l
       logger.debug({ mdx: frame, mdxCompileError }, 'Holding back invalid MDX');
       continue;
     }
-    logger.debug({ mdx: frame }, 'Streaming valid MDX');
     yield frame;
   }
   return rendered;

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -22,37 +22,64 @@ import { SidekickOutputFormat } from './sidekick.js';
  * window.
  */
 export function getShrinkableConversation(messages: ConversationMessage[], fullConversation: ConversationMessage[]) {
-  return fullConversation.map((message, messageIndex) => {
-    // Ensure that nothing in the most recent batch of messages gets dropped.
-    if (messages.length !== fullConversation.length && messages.includes(message)) {
-      return message.element;
+  // Group messages with tool IDs together because we can't leave unmatched function calls/responses.
+  const groupedMessages: ConversationMessage[][] = [[]];
+  fullConversation.forEach((message) => {
+    if (message.type === 'functionCall' || message.type === 'functionResponse') {
+      if (message.element.props.id) {
+        const lastMessage = groupedMessages.at(-1)?.at(-1);
+        if (lastMessage?.type === 'functionCall' || lastMessage?.type === 'functionResponse') {
+          if (lastMessage.element.props.id) {
+            groupedMessages.at(-1)?.push(message);
+            return;
+          }
+        }
+      }
     }
 
-    switch (message.type) {
-      case 'system':
-        // Never drop system messages.
-        return message.element;
-      case 'functionResponse':
-        // As a first pass, elide FunctionResponses.
-        return (
+    groupedMessages.push([message]);
+  });
+
+  return groupedMessages.map((group, groupIndex) => {
+    // Ensure that nothing in the most recent batch of messages gets dropped.
+    if (messages.length !== fullConversation.length && messages.find((m) => group.includes(m))) {
+      return group.map((message) => message.element);
+    }
+
+    if (group.find((message) => message.type === 'functionResponse')) {
+      // It's a group of function calls and responses. As a first pass, elide FunctionResponses.
+      const elements = group.map((message) =>
+        message.type === 'functionResponse' ? (
           <Shrinkable
             importance={0}
             replacement={
-              <Shrinkable importance={messageIndex + 1}>
-                <FunctionResponse id={message.element.props.id} name={message.element.props.name}>
-                  [snip...]
-                </FunctionResponse>
-              </Shrinkable>
+              <FunctionResponse id={message.element.props.id} name={message.element.props.name}>
+                [snip...]
+              </FunctionResponse>
             }
           >
             {message.element}
           </Shrinkable>
-        );
+        ) : (
+          message.element
+        )
+      );
+
+      // Then prune the whole group.
+      return <Shrinkable importance={groupIndex + 1}>{elements}</Shrinkable>;
+    }
+
+    const message = group[0];
+    switch (message?.type) {
+      case 'system':
+        // Never drop system messages.
+        return message.element;
       case 'user':
       case 'assistant':
       case 'functionCall':
+      case 'functionResponse':
         // Then prune oldest -> newest messages.
-        return <Shrinkable importance={messageIndex + 1}>{message.element}</Shrinkable>;
+        return <Shrinkable importance={groupIndex + 1}>{message.element}</Shrinkable>;
     }
   });
 }

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -128,7 +128,7 @@ export type FunctionParameters = Record<string, PlainFunctionParameter> | z.ZodO
 function AutomaticCompletionModel({ children, ...props }: ModelPropsWithChildren) {
   if (getEnvVar('OPENAI_API_KEY', false) || getEnvVar('OPENAI_API_BASE', false)) {
     return (
-      <OpenAICompletionModel model="text-davinci-003" {...props}>
+      <OpenAICompletionModel model="gpt-3.5-turbo-instruct" {...props}>
         {children}
       </OpenAICompletionModel>
     );

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -35,7 +35,21 @@ export function SystemMessage({ children }: { children: Node; metadata?: Record<
  *    ==> 'Sorry to hear that. Can you tell me why?
  * ```
  */
-export function UserMessage({ children }: { name?: string; children: Node; metadata?: Record<string, Jsonifiable> }) {
+export function UserMessage({
+  name,
+  children,
+}: {
+  name?: string;
+  children: Node;
+  metadata?: Record<string, Jsonifiable>;
+}) {
+  if (name) {
+    return (
+      <>
+        ({name}) {children}
+      </>
+    );
+  }
   return children;
 }
 
@@ -99,16 +113,20 @@ export function ConversationHistory(_: {}, { getContext }: AI.ComponentContext) 
  * ```
  */
 export function FunctionCall({
+  id,
   name,
   partial,
   args,
 }: {
   name: string;
+  id?: string;
   partial?: boolean;
   args: Record<string, string | number | boolean | null>;
   metadata?: Record<string, Jsonifiable>;
 }) {
-  return `Call function ${name} with ${partial ? '(incomplete) ' : ''}${JSON.stringify(args)}`;
+  return `Call function ${name}${id ? ` (id ${id})` : ''} with ${partial ? '(incomplete) ' : ''}${JSON.stringify(
+    args
+  )}`;
 }
 
 /**
@@ -128,26 +146,31 @@ export function FunctionCall({
  * ```
  */
 export function FunctionResponse({
+  id,
   name,
   failed,
   children,
 }: {
+  id?: string;
   name: string;
   failed?: boolean;
   children: Node;
   metadata?: Record<string, Jsonifiable>;
 }) {
+  const idOutput = id ? ` (id ${id})` : '';
   if (failed) {
     return (
       <>
-        function {name} failed with {children}
+        function {name}
+        {idOutput} failed with {children}
       </>
     );
   }
 
   return (
     <>
-      function {name} returned {children}
+      function {name}
+      {idOutput} returned {children}
     </>
   );
 }

--- a/packages/ai-jsx/src/core/render.ts
+++ b/packages/ai-jsx/src/core/render.ts
@@ -320,19 +320,10 @@ async function* renderStream(
     const logImpl = renderingContext.getContext(LoggerContext);
     const renderId = uuidv4();
     try {
-      /**
-       * This approach is pretty noisy because there are many internal components about which the users don't care.
-       * For instance, if the user writes <ChatCompletion>, that'll generate a bunch of internal helpers to
-       * locate + call the model provider, etc.
-       *
-       * To get around this, maybe we want components to be able to choose the loglevel used for their rendering.
-       */
-      logImpl.log('debug', renderable, renderId, 'Start rendering element');
       const finalResult = yield* renderingContext.render(
         renderable.render(renderingContext, new BoundLogger(logImpl, renderId, renderable), appendOnly),
         recursiveRenderOpts
       );
-      logImpl.log('debug', renderable, renderId, { finalResult }, 'Finished rendering element');
       return finalResult;
     } catch (ex) {
       logImpl.logException(renderable, renderId, ex);

--- a/packages/ai-jsx/src/lib/anthropic.tsx
+++ b/packages/ai-jsx/src/lib/anthropic.tsx
@@ -126,9 +126,7 @@ export async function* AnthropicChatModel(
       .map(async (message) => {
         switch (message.type) {
           case 'user':
-            return `${AnthropicSDK.HUMAN_PROMPT}${
-              message.element.props.name ? ` (${message.element.props.name})` : ''
-            } ${await render(message.element)}`;
+            return `${AnthropicSDK.HUMAN_PROMPT} ${await render(message.element)}`;
           case 'assistant':
           case 'functionCall':
           case 'functionResponse':

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -341,8 +341,8 @@ export async function* OpenAIChatModel(
     promptTokenLimit
   );
 
-  const messages: OpenAIClient.Chat.CreateChatCompletionRequestMessage[] = await Promise.all(
-    conversationMessages.map(async (message) => {
+  const messages = await Promise.all(
+    conversationMessages.map(async (message): Promise<OpenAIClient.Chat.ChatCompletionMessageParam> => {
       switch (message.type) {
         case 'system':
           return {
@@ -353,7 +353,6 @@ export async function* OpenAIChatModel(
           return {
             role: 'user',
             content: await render(message.element),
-            name: message.element.props.name,
           };
         case 'assistant':
           return {
@@ -361,6 +360,21 @@ export async function* OpenAIChatModel(
             content: await render(message.element),
           };
         case 'functionCall':
+          if (message.element.props.id) {
+            // N.B. Adjacent tool calls will be merged below.
+            return {
+              role: 'assistant',
+              content: '',
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: message.element.props.name, arguments: JSON.stringify(message.element.props.args) },
+                  id: message.element.props.id,
+                },
+              ],
+            };
+          }
+
           return {
             role: 'assistant',
             content: '',
@@ -370,6 +384,14 @@ export async function* OpenAIChatModel(
             },
           };
         case 'functionResponse':
+          if (message.element.props.id) {
+            return {
+              role: 'tool',
+              tool_call_id: message.element.props.id,
+              content: await render(message.element.props.children),
+            };
+          }
+
           return {
             role: 'function',
             name: message.element.props.name,
@@ -387,23 +409,48 @@ export async function* OpenAIChatModel(
     );
   }
 
-  const openaiFunctions = !props.functionDefinitions
+  // Merge adjacent tool calls.
+  const mergedMessages = messages.reduce<OpenAIClient.Chat.ChatCompletionMessageParam[]>((mergedMessages, message) => {
+    if (message.role === 'assistant' && message.tool_calls && message.content === '') {
+      const lastMessage = mergedMessages[mergedMessages.length - 1];
+      if (lastMessage.role === 'assistant' && lastMessage.tool_calls) {
+        // Merge with the last message.
+        return [
+          ...mergedMessages.slice(0, -1),
+          {
+            ...lastMessage,
+            tool_calls: [...lastMessage.tool_calls, ...message.tool_calls],
+          },
+        ];
+      }
+    }
+    return mergedMessages.concat([message]);
+  }, []);
+
+  const openaiTools = !props.functionDefinitions
     ? []
-    : Object.entries(props.functionDefinitions).map(([functionName, functionDefinition]) => ({
-        name: functionName,
-        description: functionDefinition.description,
-        parameters: getParametersSchema(functionDefinition.parameters),
-      }));
+    : Object.entries(props.functionDefinitions).map<OpenAIClient.Chat.ChatCompletionTool>(
+        ([functionName, functionDefinition]) => ({
+          function: {
+            name: functionName,
+            description: functionDefinition.description,
+            parameters: getParametersSchema(functionDefinition.parameters),
+          },
+          type: 'function',
+        })
+      );
 
   const openai = getContext(openAiClientContext)();
-  const chatCompletionRequest = {
+  const chatCompletionRequest: OpenAIClient.Chat.Completions.ChatCompletionCreateParamsStreaming = {
     model: props.model,
     max_tokens: props.maxTokens,
     temperature: props.temperature,
     top_p: props.topP,
-    messages,
-    functions: openaiFunctions.length > 0 ? openaiFunctions : undefined,
-    function_call: props.forcedFunction ? { name: props.forcedFunction } : undefined,
+    messages: mergedMessages,
+    tools: openaiTools.length > 0 ? openaiTools : undefined,
+    tool_choice: props.forcedFunction
+      ? { function: { name: props.forcedFunction }, type: 'function' as const }
+      : undefined,
     stop: props.stop,
     logit_bias: props.logitBias ? logitBiasOfTokens(props.logitBias) : undefined,
     stream: true as const,
@@ -469,7 +516,7 @@ export async function* OpenAIChatModel(
             accumulatedContent += delta.content;
             yield delta.content;
           }
-          if (delta.function_call) {
+          if (delta.tool_calls) {
             break;
           }
           delta = await advance();
@@ -492,31 +539,44 @@ export async function* OpenAIChatModel(
 
     // TS doesn't realize that the Stream closure can make `delta` be `null`.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (delta?.function_call) {
+    while (delta?.tool_calls) {
       // Memoize the stream to ensure it renders only once.
       const functionCallStream = memo(
         (async function* () {
+          let id = undefined;
           let name = '';
           let argsJson = '';
           while (delta != null) {
-            if (!delta.function_call) {
+            if (!delta.tool_calls) {
               break;
             }
 
-            if (delta.function_call.name) {
-              name += delta.function_call.name;
+            const toolCall = delta.tool_calls[0];
+            if (toolCall.id) {
+              if (id === undefined) {
+                id = toolCall.id;
+              } else if (id !== toolCall.id) {
+                // The ID changed, so we're done with this function call.
+                break;
+              }
             }
 
-            if (delta.function_call.arguments) {
-              argsJson += delta.function_call.arguments;
+            if (toolCall.function?.name) {
+              name += toolCall.function.name;
             }
 
-            yield <FunctionCall partial name={name} args={JSON.parse(patchedUntruncateJson(argsJson || '{}'))} />;
+            if (toolCall.function?.arguments) {
+              argsJson += toolCall.function.arguments;
+            }
+
+            yield (
+              <FunctionCall id={id} partial name={name} args={JSON.parse(patchedUntruncateJson(argsJson || '{}'))} />
+            );
 
             delta = await advance();
           }
 
-          return <FunctionCall name={name} args={JSON.parse(argsJson || '{}')} />;
+          return <FunctionCall id={id} name={name} args={JSON.parse(argsJson || '{}')} />;
         })()
       );
       yield functionCallStream;

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -32,7 +32,8 @@ export type ValidCompletionModel =
   | 'text-davinci-002'
   | 'text-curie-001'
   | 'text-babbage-001'
-  | 'text-ada-001';
+  | 'text-ada-001'
+  | 'gpt-3.5-turbo-instruct';
 
 export type ValidChatModel =
   | 'gpt-4'
@@ -41,11 +42,13 @@ export type ValidChatModel =
   | 'gpt-4-32k'
   | 'gpt-4-32k-0314' // discontinue on 06/13/2024
   | 'gpt-4-32k-0613'
+  | 'gpt-4-1106-preview'
   | 'gpt-3.5-turbo'
   | 'gpt-3.5-turbo-0301' // discontinue on 06/13/2024
   | 'gpt-3.5-turbo-0613'
   | 'gpt-3.5-turbo-16k'
-  | 'gpt-3.5-turbo-16k-0613';
+  | 'gpt-3.5-turbo-16k-0613'
+  | 'gpt-3.5-turbo-1106';
 
 /**
  * An OpenAI client that talks to the Azure OpenAI service.

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -251,9 +251,11 @@ function tokenLimitForChatModel(
     case 'gpt-3.5-turbo-16k-0613':
     case 'gpt-3.5-turbo-1106':
       return 16384 - functionEstimate - TOKENS_CONSUMED_BY_REPLY_PREFIX;
-    default:
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = model;
       return undefined;
+    }
   }
 }
 
@@ -377,27 +379,22 @@ export async function* OpenAIChatModel(
   };
 
   for (const message of conversationMessages) {
-    switch (message.type) {
-      case 'functionCall':
-        if (activeFunctionResponses.length > 0) {
-          flushActiveIds();
-        }
-
-        const id = message.element.props.id;
-        if (id) {
-          activeFunctionCalls.push(id);
-        }
-        break;
-      case 'functionResponse': {
-        const id = message.element.props.id;
-        if (id) {
-          activeFunctionResponses.push(id);
-        }
-        break;
-      }
-      default:
+    if (message.type === 'functionCall') {
+      if (activeFunctionResponses.length > 0) {
         flushActiveIds();
-        break;
+      }
+
+      const id = message.element.props.id;
+      if (id) {
+        activeFunctionCalls.push(id);
+      }
+    } else if (message.type === 'functionResponse') {
+      const id = message.element.props.id;
+      if (id) {
+        activeFunctionResponses.push(id);
+      }
+    } else {
+      flushActiveIds();
     }
   }
   flushActiveIds();

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -241,14 +241,18 @@ function tokenLimitForChatModel(
     case 'gpt-4-32k-0314':
     case 'gpt-4-32k-0613':
       return 32768 - functionEstimate - TOKENS_CONSUMED_BY_REPLY_PREFIX;
+    case 'gpt-4-1106-preview':
+      return 128_000 - functionEstimate - TOKENS_CONSUMED_BY_REPLY_PREFIX;
     case 'gpt-3.5-turbo':
     case 'gpt-3.5-turbo-0301':
     case 'gpt-3.5-turbo-0613':
       return 4096 - functionEstimate - TOKENS_CONSUMED_BY_REPLY_PREFIX;
     case 'gpt-3.5-turbo-16k':
     case 'gpt-3.5-turbo-16k-0613':
+    case 'gpt-3.5-turbo-1106':
       return 16384 - functionEstimate - TOKENS_CONSUMED_BY_REPLY_PREFIX;
     default:
+      const _: never = model;
       return undefined;
   }
 }

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 0.22.1
+## 0.23.0
+
+- Update the model enums in `ai-jsx/lib/openai`
+
+## [0.22.1](https://github.com/fixie-ai/ai-jsx/commit/90370c40bccc779e5e49e830f917fd35bcbb87f1)
 
 - In the OpenTelemetry logger, ensure that SeverityNumber is set.
 

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.23.0
+## 0.24.0
+
+- Update OpenAI client to 4.16.0
+- Add support for OpenAI parallel function calls
+
+## [0.23.0](https://github.com/fixie-ai/ai-jsx/commit/e61c8acff105f69458377f94347e920ade5b9772)
 
 - Update the model enums in `ai-jsx/lib/openai`
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -21,7 +21,6 @@
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
     "nock": "^13.3.2",
-    "openai": "^4.1.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3"

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -2,6 +2,7 @@ import * as math from 'mathjs';
 import { Tool, UseTools } from 'ai-jsx/batteries/use-tools';
 import { showInspector } from 'ai-jsx/core/inspector';
 import { UserMessage, ShowConversation } from 'ai-jsx/core/conversation';
+import { OpenAI } from 'ai-jsx/lib/openai';
 
 function evaluate({ expression }: { expression: string }) {
   return math.evaluate(expression);
@@ -51,11 +52,13 @@ function App({ query }: { query: string }) {
         }
       }}
     >
-      <UseTools showSteps tools={tools}>
-        <UserMessage>{query}</UserMessage>
-      </UseTools>
+      <OpenAI chatModel="gpt-3.5-turbo-1106">
+        <UseTools showSteps tools={tools}>
+          <UserMessage>{query}</UserMessage>
+        </UseTools>
+      </OpenAI>
     </ShowConversation>
   );
 }
 
-showInspector(<App query="What is 2523231 * 2382382?" />);
+showInspector(<App query="What is 2523231 * 2382382? What about 1551234 * 874720?" />);

--- a/packages/examples/test/batteries/use-tools.tsx
+++ b/packages/examples/test/batteries/use-tools.tsx
@@ -14,7 +14,7 @@ async function FakeChatCompletion({ children }: { children: AI.Node }, { render 
   if (nodes.find((n) => n.type === 'functionCall')) {
     return <AssistantMessage>DONE</AssistantMessage>;
   }
-  return <FunctionCall name="myFunc" args={{ parameter: 'test parameter value' }} />;
+  return <FunctionCall id="$myFunc" name="myFunc" args={{ parameter: 'test parameter value' }} />;
 }
 
 it('should call a tool', async () => {
@@ -52,8 +52,8 @@ it('should call a tool', async () => {
   );
 
   expect(result).toMatchInlineSnapshot(`
-    "functionCall: Call function myFunc with {"parameter":"test parameter value"}
-    functionResponse: function myFunc returned TEST PARAMETER VALUE
+    "functionCall: Call function myFunc (id $myFunc) with {"parameter":"test parameter value"}
+    functionResponse: function myFunc (id $myFunc) returned TEST PARAMETER VALUE
     assistant: DONE
     "
   `);
@@ -106,8 +106,8 @@ it('should give tools access to context', async () => {
   );
 
   expect(result).toMatchInlineSnapshot(`
-    "functionCall: Call function myFunc with {"parameter":"test parameter value"}
-    functionResponse: function myFunc returned test parameter value: 42
+    "functionCall: Call function myFunc (id $myFunc) with {"parameter":"test parameter value"}
+    functionResponse: function myFunc (id $myFunc) returned test parameter value: 42
     assistant: DONE
     "
   `);
@@ -156,8 +156,8 @@ it('should handle failures', async () => {
   );
 
   expect(result).toMatchInlineSnapshot(`
-    "functionCall: Call function myFunc with {"parameter":"test parameter value"}
-    functionResponse: function myFunc failed with Error: ERROR!
+    "functionCall: Call function myFunc (id $myFunc) with {"parameter":"test parameter value"}
+    functionResponse: function myFunc (id $myFunc) failed with Error: ERROR!
     assistant: DONE
     "
   `);

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -36,7 +36,7 @@ import nock from 'nock';
 import * as AI from 'ai-jsx';
 import { ChatCompletion } from 'ai-jsx/core/completion';
 import { FunctionCall, FunctionResponse, UserMessage, SystemMessage, Shrinkable } from 'ai-jsx/core/conversation';
-import { OpenAI } from 'ai-jsx/lib/openai';
+import { OpenAI, OpenAIClient } from 'ai-jsx/lib/openai';
 import { Tool } from 'ai-jsx/batteries/use-tools';
 import { Anthropic } from 'ai-jsx/lib/anthropic';
 import { CompletionCreateParams } from '@anthropic-ai/sdk/resources/completions';
@@ -45,7 +45,6 @@ import { Jsonifiable } from 'type-fest';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SimpleSpanProcessor, InMemorySpanExporter } from '@opentelemetry/sdk-trace-base';
 import _ from 'lodash';
-import { type OpenAI as OpenAIClient } from 'openai';
 
 afterEach(() => {
   fetchMock.resetMocks();
@@ -369,18 +368,21 @@ describe('functions', () => {
 
     expect(handleRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        functions: [
+        tools: [
           {
-            name: 'myFunc',
-            description: 'My function',
-            parameters: {
-              type: 'object',
-              required: ['myParam'],
-              properties: {
-                myParam: {
-                  type: 'string',
-                  enum: ['option1', 'option2'],
-                  description: 'My parameter',
+            type: 'function',
+            function: {
+              name: 'myFunc',
+              description: 'My function',
+              parameters: {
+                type: 'object',
+                required: ['myParam'],
+                properties: {
+                  myParam: {
+                    type: 'string',
+                    enum: ['option1', 'option2'],
+                    description: 'My parameter',
+                  },
                 },
               },
             },
@@ -484,7 +486,7 @@ function mockOpenAIResponse(message: string, handleRequest?: jest.MockedFn<(req:
           function sendDelta(messagePart: string) {
             const response: OpenAIClient.Chat.Completions.ChatCompletionChunk = {
               id: 'cmpl-3QJ8ZjX1J5Z5X',
-              object: 'text_completion',
+              object: 'chat.completion.chunk',
               created: 1624430979,
               model: 'gpt-3.5-turbo',
               choices: [

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/src/conversation.tsx
+++ b/packages/fixie-sdk/src/conversation.tsx
@@ -47,10 +47,18 @@ export async function FixieConversation(_: {}, { getContext }: AI.ComponentConte
             <UserMessage metadata={message.metadata}>{message.content}</UserMessage>
           );
         case 'functionCall':
-          return <FunctionCall name={message.name} args={message.args} metadata={message.metadata} />;
+          return (
+            <FunctionCall
+              id={message.id}
+              partial={message.partial}
+              name={message.name}
+              args={message.args}
+              metadata={message.metadata}
+            />
+          );
         case 'functionResponse':
           return (
-            <FunctionResponse name={message.name} failed={message.failed} metadata={message.metadata}>
+            <FunctionResponse id={message.id} name={message.name} failed={message.failed} metadata={message.metadata}>
               {message.response}
             </FunctionResponse>
           );

--- a/packages/fixie-sdk/src/request-wrapper.tsx
+++ b/packages/fixie-sdk/src/request-wrapper.tsx
@@ -62,6 +62,8 @@ export function FixieRequestWrapper({
               <Json>
                 {{
                   kind: 'functionCall',
+                  id: message.element.props.id,
+                  partial: message.element.props.partial,
                   name: message.element.props.name,
                   args: message.element.props.args,
                   metadata: message.element.props.metadata,
@@ -74,6 +76,7 @@ export function FixieRequestWrapper({
               <Json>
                 {{
                   kind: 'functionResponse',
+                  id: message.element.props.id,
                   name: message.element.props.name,
                   response: <>{message.element.props.children}</>,
                   metadata: message.element.props.metadata,
@@ -95,7 +98,7 @@ export function FixieRequestWrapper({
         new OpenAIClient({
           apiKey: fixieAuthToken,
           baseURL: new URL('api/openai-proxy/v1', fixieApiUrl).toString(),
-          fetch: globalThis.fetch,
+          fetch: globalThis.fetch as any,
         })
       }
       chatModel="gpt-3.5-turbo"

--- a/packages/fixie-sdk/src/types.ts
+++ b/packages/fixie-sdk/src/types.ts
@@ -6,12 +6,15 @@ export interface MessageBase {
 
 export interface FunctionCallMessage extends MessageBase {
   kind: 'functionCall';
+  id?: string;
+  partial?: boolean;
   name: string;
   args: Record<string, string | number | boolean | null>;
 }
 
 export interface FunctionResponseMessage extends MessageBase {
   kind: 'functionResponse';
+  id?: string;
   name: string;
   response: string;
   failed: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7307,7 +7307,7 @@ __metadata:
     ml-distance: ^4.0.1
     mpg123-decoder: ^0.4.9
     node-fetch: ^3.3.1
-    openai: ^4.1.0
+    openai: ^4.16.0
     pino: ^8.14.1
     pino-pretty: ^10.0.0
     react: ^18.2.0
@@ -12364,7 +12364,6 @@ __metadata:
     mathjs: ^11.8.1
     nock: ^13.3.2
     node-fetch: ^3.3.1
-    openai: ^4.1.0
     pino: ^8.14.1
     pino-pretty: ^10.0.0
     prompt-sync: ^4.2.0
@@ -19348,9 +19347,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "openai@npm:4.1.0"
+"openai@npm:^4.16.0":
+  version: 4.16.0
+  resolution: "openai@npm:4.16.0"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
@@ -19360,9 +19359,10 @@ __metadata:
     form-data-encoder: 1.7.2
     formdata-node: ^4.3.2
     node-fetch: ^2.6.7
+    web-streams-polyfill: ^3.2.1
   bin:
     openai: bin/cli
-  checksum: 26b4484345b7a09e0524ff187488f4e3c96331791e1e87af8d49ef8bb67bb5ecaaa9c6d212f0a246be058089ad331ddcaacd3fc0b89fc8e1053e884b2fedd959
+  checksum: 4b90d7f93dc2b590d1068f430d7d919ec57277a4128be954c2b60cea5fd0a7f06eb6184231f0cd60b1e6fd20e306729f978639470bdbe21344ea5e13afcc4c93
   languageName: node
   linkType: hard
 
@@ -25795,7 +25795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-streams-polyfill@npm:^3.0.3":
+"web-streams-polyfill@npm:^3.0.3, web-streams-polyfill@npm:^3.2.1":
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02


### PR DESCRIPTION
This adds support for OpenAI's new parallel function calls, where a single inference can request multiple function calls.

It consists of:
- Updating the OpenAI SDK version
- Using the new "tools" contracts
- Plumbing IDs to relate function call requests and corresponding results
- Supporting executing multiple function calls in parallel in `<UseTools>` and `<Sidekick>`