### PR TITLE
Give <Sidekick> the ability to interject messages prior to the first function call

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "prettier": "^2.8.8",
-    "turbo": "^1.10.4",
+    "turbo": "^1.10.16",
     "typescript": "^5.1.3"
   },
   "type": "module",

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -106,7 +106,7 @@ export function getNextConversationStep(
   fullConversation: ConversationMessage[],
   outputFormat: SidekickOutputFormat,
   tools: UseToolsProps['tools'] | undefined,
-  functionCallInterjection: AI.Node
+  beforeFunctionCallInterjection: AI.Node
 ) {
   const shrinkableConversation = getShrinkableConversation(messages, fullConversation);
   const lastMessage = messages[messages.length - 1];
@@ -170,7 +170,7 @@ export function getNextConversationStep(
       const lastAssistantMessage = messages.findLast((m) => m.type === 'assistant');
       if (
         hasTools &&
-        functionCallInterjection &&
+        beforeFunctionCallInterjection &&
         // Ensure we don't interject if the last assistant message was already an interjection. (If back to back generations
         // request function calls, we don't want to interject twice.)
         !lastAssistantMessage?.element.props.metadata?.isFunctionCallInterjection
@@ -179,7 +179,7 @@ export function getNextConversationStep(
           <InterjectBeforeFunctionCall
             interjection={
               <AssistantMessage metadata={{ isFunctionCallInterjection: true }}>
-                {functionCallInterjection}
+                {beforeFunctionCallInterjection}
               </AssistantMessage>
             }
           >

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -11,6 +11,7 @@ import {
   Shrinkable,
   renderToConversation,
   SystemMessage,
+  ShowConversation,
 } from '../../../core/conversation.js';
 import { LargeFunctionResponseWrapper, redactedFunctionTools } from './large-response-handler.js';
 import { ExecuteFunction, UseToolsProps } from '../../use-tools.js';
@@ -69,6 +70,28 @@ export function present(conversationElement: ConversationMessage, outputFormat: 
 }
 
 /**
+ * Interjects content if the first conversation message in the children is a function call.
+ */
+function InterjectBeforeFunctionCall(
+  { interjection, children }: { interjection: AI.Node; children: AI.Node },
+  { memo }: AI.ComponentContext
+) {
+  const memoizedInterjection = memo(interjection);
+  return (
+    <ShowConversation
+      present={(message, index) => {
+        if (index === 0 && message.type === 'functionCall') {
+          return [memoizedInterjection, message.element];
+        }
+        return message.element;
+      }}
+    >
+      {children}
+    </ShowConversation>
+  );
+}
+
+/**
  * This is the conversation state machine. It takes the current conversation and decides how to respond.
  *
  * For instance, if the most recent message is a function call, it will call the function and return a FunctionResponse.
@@ -82,10 +105,12 @@ export function getNextConversationStep(
   messages: ConversationMessage[],
   fullConversation: ConversationMessage[],
   outputFormat: SidekickOutputFormat,
-  tools?: UseToolsProps['tools']
+  tools: UseToolsProps['tools'] | undefined,
+  functionCallInterjection: AI.Node
 ) {
   const shrinkableConversation = getShrinkableConversation(messages, fullConversation);
   const lastMessage = messages[messages.length - 1];
+  const hasTools = tools && Object.keys(tools).length > 0;
 
   // Add tools for interacting with redacted function responses (if one exists).
   // We will only take into account the current round of messages (after last UserMessage). In the next round
@@ -136,9 +161,32 @@ export function getNextConversationStep(
     case 'system':
     case 'user':
     case 'functionResponse': {
-      const generation = (
-        <ChatCompletion functionDefinitions={tools ? updatedTools : undefined}>{shrinkableConversation}</ChatCompletion>
+      let generation = (
+        <ChatCompletion functionDefinitions={hasTools ? updatedTools : undefined}>
+          {shrinkableConversation}
+        </ChatCompletion>
       );
+
+      const lastAssistantMessage = messages.findLast((m) => m.type === 'assistant');
+      if (
+        hasTools &&
+        functionCallInterjection &&
+        // Ensure we don't interject if the last assistant message was already an interjection.
+        !lastAssistantMessage?.element.props.metadata?.isFunctionCallInterjection
+      ) {
+        generation = (
+          <InterjectBeforeFunctionCall
+            interjection={
+              <AssistantMessage metadata={{ isFunctionCallInterjection: true }}>
+                {functionCallInterjection}
+              </AssistantMessage>
+            }
+          >
+            {generation}
+          </InterjectBeforeFunctionCall>
+        );
+      }
+
       return outputFormat === 'text/mdx' ? <RepairMdxInConversation>{generation}</RepairMdxInConversation> : generation;
     }
     default:

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -169,7 +169,6 @@ export function getNextConversationStep(
 
       const lastAssistantMessage = messages.findLast((m) => m.type === 'assistant');
       if (
-        hasTools &&
         beforeFunctionCallInterjection &&
         // Ensure we don't interject if the last assistant message was already an interjection. (If back to back generations
         // request function calls, we don't want to interject twice.)

--- a/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/conversation.tsx
@@ -171,7 +171,8 @@ export function getNextConversationStep(
       if (
         hasTools &&
         functionCallInterjection &&
-        // Ensure we don't interject if the last assistant message was already an interjection.
+        // Ensure we don't interject if the last assistant message was already an interjection. (If back to back generations
+        // request function calls, we don't want to interject twice.)
         !lastAssistantMessage?.element.props.metadata?.isFunctionCallInterjection
       ) {
         generation = (

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -11,6 +11,8 @@ interface UniversalSidekickProps {
 
   /**
    * An interjection to emit when the model requests a function call without emitting any text.
+   *
+   * e.g. "Let me check on that."
    */
   functionCallInterjection?: AI.Node;
 

--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -10,6 +10,11 @@ interface UniversalSidekickProps {
   systemMessage?: AI.Node;
 
   /**
+   * An interjection to emit when the model requests a function call without emitting any text.
+   */
+  functionCallInterjection?: AI.Node;
+
+  /**
    * The conversation to act on. If not specified, uses the <ConversationHistory /> component.
    */
   children?: AI.Node;
@@ -89,7 +94,7 @@ export function Sidekick(props: SidekickProps) {
     <ShowConversation present={(msg) => present(msg, outputFormat)}>
       <Converse
         reply={(messages, fullConversation) =>
-          getNextConversationStep(messages, fullConversation, outputFormat, props.tools)
+          getNextConversationStep(messages, fullConversation, outputFormat, props.tools, props.functionCallInterjection)
         }
       >
         {props.systemMessage}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7261,7 +7261,7 @@ __metadata:
     eslint-import-resolver-typescript: ^3.5.5
     eslint-plugin-import: ^2.27.5
     prettier: ^2.8.8
-    turbo: ^1.10.4
+    turbo: ^1.10.16
     typescript: ^5.1.3
   languageName: unknown
   linkType: soft
@@ -24621,58 +24621,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-darwin-64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-darwin-64@npm:1.10.6"
+"turbo-darwin-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-64@npm:1.10.16"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-darwin-arm64@npm:1.10.6"
+"turbo-darwin-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-arm64@npm:1.10.16"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-linux-64@npm:1.10.6"
+"turbo-linux-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-64@npm:1.10.16"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-linux-arm64@npm:1.10.6"
+"turbo-linux-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-arm64@npm:1.10.16"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-windows-64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-windows-64@npm:1.10.6"
+"turbo-windows-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-64@npm:1.10.16"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:1.10.6":
-  version: 1.10.6
-  resolution: "turbo-windows-arm64@npm:1.10.6"
+"turbo-windows-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-arm64@npm:1.10.16"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo@npm:^1.10.4":
-  version: 1.10.6
-  resolution: "turbo@npm:1.10.6"
+"turbo@npm:^1.10.16":
+  version: 1.10.16
+  resolution: "turbo@npm:1.10.16"
   dependencies:
-    turbo-darwin-64: 1.10.6
-    turbo-darwin-arm64: 1.10.6
-    turbo-linux-64: 1.10.6
-    turbo-linux-arm64: 1.10.6
-    turbo-windows-64: 1.10.6
-    turbo-windows-arm64: 1.10.6
+    turbo-darwin-64: 1.10.16
+    turbo-darwin-arm64: 1.10.16
+    turbo-linux-64: 1.10.16
+    turbo-linux-arm64: 1.10.16
+    turbo-windows-64: 1.10.16
+    turbo-windows-arm64: 1.10.16
   dependenciesMeta:
     turbo-darwin-64:
       optional: true
@@ -24688,7 +24688,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 920985d59b088e3e203450ee42446a4e0efa7de3a6455828146089e0e9efc4981e52998f7c13fcb730158e652d84bfc49149ebe33ab4a4cc033db7ab32934390
+  checksum: 69d1892593449b264e0bd48b851317a743016ab62cf470e7293b2cc3781240e863c48232c89f65a5a4ce97eb791ca550b201593449350da073db07703a19cfa5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds the ability for the `<Sidekick>` component to interject assistant text (e.g. "Let me check on that.") if the first message in a generation is a function call and the most recent `<AssistantMessage>` was not an interjection.

It's currently empty by default.