### PR TITLE
Slimming down system message

### DIFF
--- a/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/sidekick.tsx
@@ -94,10 +94,12 @@ export function Sidekick(props: SidekickProps) {
       >
         {props.systemMessage}
         <SidekickSystemMessage
-          timeZone="America/Los_Angeles"
+          // TODO: get timeZone from the user's browser
           includeNextStepsRecommendations={
             outputFormat === 'text/mdx' && (props.includeNextStepsRecommendations ?? true)
           }
+          // check if there are any tools instead of explicitly checking if there's a knowledge base
+          hasKnowledgeBase={Object.keys(props.tools ?? {}).length === 0}
           useCitationCard={outputFormat === 'text/mdx' && (props.useCitationCard ?? true)}
           outputFormat={outputFormat}
           userProvidedGenUIUsageExamples={props.genUIExamples}

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -23,7 +23,7 @@ export function SidekickSystemMessage({
   useCitationCard,
   outputFormat,
 }: SidekickSystemMessageProps) {
-  /* Format: 'Friday, Nov 10, 2023, 1:46:34 PM' */
+  /* Format: 'Friday, Nov 10, 2023, 1:46:34 PM PST' */
   const dateStringOptions = {
     weekday: 'long',
     year: 'numeric',
@@ -33,23 +33,27 @@ export function SidekickSystemMessage({
     minute: 'numeric',
     second: 'numeric',
     hour12: true,
-    timeZone,
+    timeZone: timeZone ?? 'America/Los_Angeles',
+    timeZoneName: 'short',
   } as const;
 
   const dateTimeSystemMessage = (
     <>
       Current time: {new Date().toLocaleString('en-us', dateStringOptions)}.
-      {timeZone ? `User's local time zone: ${timeZone}. When giving dates, use this time zone.` : ''}
-      If a time is not specified by user, assume it is intended now or in the near future. Timestamps you provide should
-      be human-readable.
+      {timeZone ? ` User's local time zone: ${timeZone}. When giving dates, use this time zone.` : ''}
+      <>
+        {' '}
+        If a time is not specified by user, assume it is intended now or in the near future. Timestamps you provide
+        should be human-readable.
+      </>
     </>
   );
 
   const responseFormatSystemMessage = (
-    <>Do not say "according to the documents I have been given", just answer as if you know the answer.</>
+    <> Do not say "according to the documents I have been given", just answer as if you know the answer.</>
   );
 
-  const styleSystemMessage = <>Speak politely but casually.</>;
+  const styleSystemMessage = <> Speak politely but casually.</>;
 
   const baseComponentNames = [];
   if (includeNextStepsRecommendations) {
@@ -84,7 +88,7 @@ export function SidekickSystemMessage({
       {dateTimeSystemMessage}
       {hasKnowledgeBase && responseFormatSystemMessage}
       {styleSystemMessage}
-      {outputFormatToUse === 'text/markdown' && <>Respond with Markdown.</>}
+      {outputFormatToUse === 'text/markdown' && <> Respond with Markdown.</>}
       {outputFormatToUse === 'text/mdx' && (
         <MdxSystemMessage
           componentNames={allComponents}

--- a/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/system-message.tsx
@@ -7,8 +7,9 @@ import { SidekickOutputFormat } from './sidekick.js';
 export interface SidekickSystemMessageProps {
   outputFormat: SidekickOutputFormat;
   includeNextStepsRecommendations: boolean;
+  hasKnowledgeBase: boolean;
   useCitationCard: boolean;
-  timeZone: string;
+  timeZone?: string;
   userProvidedGenUIUsageExamples?: Node;
   userProvidedGenUIComponentNames?: string[];
 }
@@ -18,27 +19,37 @@ export function SidekickSystemMessage({
   userProvidedGenUIUsageExamples,
   userProvidedGenUIComponentNames,
   includeNextStepsRecommendations,
+  hasKnowledgeBase,
   useCitationCard,
   outputFormat,
 }: SidekickSystemMessageProps) {
-  const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  const currentDate = daysOfWeek[new Date().getDay()];
+  /* Format: 'Friday, Nov 10, 2023, 1:46:34 PM' */
+  const dateStringOptions = {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: true,
+    timeZone,
+  } as const;
 
   const dateTimeSystemMessage = (
-    <SystemMessage>
-      The current date and time is: {new Date().toLocaleString()}. The current day of the week is: {currentDate}. The
-      user's local time zone is {timeZone}. When giving dates, use the user's time zone. If the user does not specify a
-      date or time, assume it is intended either now or in the near future.
-    </SystemMessage>
+    <>
+      Current time: {new Date().toLocaleString('en-us', dateStringOptions)}.
+      {timeZone ? `User's local time zone: ${timeZone}. When giving dates, use this time zone.` : ''}
+      If a time is not specified by user, assume it is intended now or in the near future. Timestamps you provide should
+      be human-readable.
+    </>
   );
 
-  const responseFramingSystemMessage = (
-    <SystemMessage>
-      Do not say "according to the documents I have been given", just answer as if you know the answer. When you see
-      timestamps in your source data, format them in a human-readable way. Speak politely but casually. Say `use`
-      instead of `utilize`.
-    </SystemMessage>
+  const responseFormatSystemMessage = (
+    <>Do not say "according to the documents I have been given", just answer as if you know the answer.</>
   );
+
+  const styleSystemMessage = <>Speak politely but casually.</>;
 
   const baseComponentNames = [];
   if (includeNextStepsRecommendations) {
@@ -69,10 +80,11 @@ export function SidekickSystemMessage({
   }
 
   return (
-    <>
+    <SystemMessage>
       {dateTimeSystemMessage}
-      {responseFramingSystemMessage}
-      {outputFormatToUse === 'text/markdown' && <SystemMessage>Respond with Markdown.</SystemMessage>}
+      {hasKnowledgeBase && responseFormatSystemMessage}
+      {styleSystemMessage}
+      {outputFormatToUse === 'text/markdown' && <>Respond with Markdown.</>}
       {outputFormatToUse === 'text/mdx' && (
         <MdxSystemMessage
           componentNames={allComponents}
@@ -87,6 +99,6 @@ export function SidekickSystemMessage({
           }
         />
       )}
-    </>
+    </SystemMessage>
   );
 }


### PR DESCRIPTION
This PR tries to slim down the default System message for Sidekicks.

General changes:
- Trying to reduce unneeded words (I didn't go so far, but [LLMLingua](https://llmlingua.com/) shows that LLMs can understand a highly shortened format of language)
- The "document system message" is used only if there Sidekick has some `tools`. Corpus vs other tools are not disambiguated
- Reducing number of System messages: not a large factor, but I verified that each additional system message uses about 4 extra tokens
- Date format change
    - before: `11/10/2023, 1:46:34 PM .... Friday`
    - after: `Friday, Nov 10, 2023, 1:46:34 PM`
    - Interestingly, this uses slightly less tokens (not including actual prompt changes) while disambiguating 11/10 (US "standard" ...) to Nov 10

Token count for plain text mode (text only):
- before: 136 (probably slightly higher due to having multiple system messages)
- after (with tools): 77
- after (w/o tools): 56