### PR TITLE
Add command-line flags for returning agent logs.

### DIFF
--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -303,9 +303,48 @@ export class FixieAgent {
   }
 
   /** Return logs for this Agent. Returns the last 15 minutes of agent logs. */
-  async getLogs(): Promise<AgentLogEntry[]> {
-    // TODO: Expand parameters here to specify start/end times, deal with pagination, etc.
-    const retval = await this.client.request(`/api/v1/agents/${this.metadata.uuid}/logs`);
+  async getLogs({
+    start,
+    end,
+    limit,
+    offset,
+    minSeverity,
+    conversationId,
+    messageId,
+  }: {
+    start?: Date;
+    end?: Date;
+    limit?: number;
+    offset?: number;
+    minSeverity?: number;
+    conversationId?: string;
+    messageId?: string;
+  }): Promise<AgentLogEntry[]> {
+    // We don't actually care about the full URL here. We're only using the
+    // URL to build up the query parameters.
+    const url = new URL('http://localhost/');
+    if (start) {
+      url.searchParams.append('startTimestamp', Math.floor(start.getTime() / 1000).toString());
+    }
+    if (end) {
+      url.searchParams.append('endTimestamp', Math.floor(end.getTime() / 1000).toString());
+    }
+    if (limit) {
+      url.searchParams.append('limit', limit.toString());
+    }
+    if (offset) {
+      url.searchParams.append('offset', offset.toString());
+    }
+    if (minSeverity) {
+      url.searchParams.append('minSeverity', minSeverity.toString());
+    }
+    if (conversationId) {
+      url.searchParams.append('conversationId', conversationId);
+    }
+    if (messageId) {
+      url.searchParams.append('messageId', messageId);
+    }
+    const retval = await this.client.request(`/api/v1/agents/${this.metadata.uuid}/logs${url.search}`);
     if (retval.status !== 200) {
       return [];
     }

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -33,6 +33,15 @@ function showResult(result: any, raw: boolean) {
   }
 }
 
+/** Parse the provided value as a Date. */
+function parseDate(value: string): Date {
+  const parsedDate = new Date(value);
+  if (isNaN(parsedDate.getTime())) {
+    throw new Error('Invalid date format.');
+  }
+  return parsedDate;
+}
+
 /** Deploy an agent from the current directory. */
 function registerDeployCommand(command: Command) {
   command
@@ -592,11 +601,29 @@ agent
 agent
   .command('logs <agentId>')
   .description('Fetch agent logs.')
+  .option('--start <date>', 'Start date', parseDate)
+  .option('--end <date>', 'End date', parseDate)
+  .option('--limit <number>', 'Max number of results to return')
+  .option('--offset <number>', 'Starting offset of results to return')
+  .option('--minSeverity <number>', 'Minimum log severity level')
+  .option('--conversation <string>', 'Conversation ID of logs to return')
+  .option('--message <string>', 'Message ID of logs to return')
   .action(
-    catchErrors(async (agentId: string) => {
+    catchErrors(async (agentId: string, opts) => {
       const client = await AuthenticateOrLogIn({ apiUrl: program.opts().url });
       const result = await FixieAgent.GetAgent({ client, agentId });
-      showResult(await result.getLogs(), program.opts().raw);
+      showResult(
+        await result.getLogs({
+          start: opts.start,
+          end: opts.end,
+          limit: opts.limit,
+          offset: opts.offset,
+          minSeverity: opts.minSeverity,
+          conversationId: opts.conversation,
+          messageId: opts.message,
+        }),
+        program.opts().raw
+      );
     })
   );
 


### PR DESCRIPTION
This PR completes the implementation of returning agent logs in the CLI by adding all of the fields supported by the logs fetch API as command-line flags.
