### PR TITLE
[Voice-QuickFix] Start speaking filler immediately

### DIFF
--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -186,7 +186,7 @@ export class ChatRequest {
         const currentMessage = currentTurn.messages
           .filter((m: any) => m.kind === 'text')
           .map((m: any) => m.content)
-          .join('');
+          .join('\n');
 
         if (currentMessage === this.outMessage) {
           continue;

--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -186,7 +186,7 @@ export class ChatRequest {
         const currentMessage = currentTurn.messages
           .filter((m: any) => m.kind === 'text')
           .map((m: any) => m.content)
-          .join('\n');
+          .join(' ');
 
         if (currentMessage === this.outMessage) {
           continue;


### PR DESCRIPTION
I noticed that the filler sentences (or interjections as Peter calls them, which I'm not a total fan of), don't start until after a long pause and seemed to only start after the corpus response was ready, which defeats the purpose. The issue seemed to have been due to the filler not being recognized as a separate sentence which meant TTS would not be called.

This PR adds a newline between separate `AssistantMessage` responses from Fixie to solve this issue for Fixie calls.

Note that I did not investigate what happens in the other cases (LLM not from Fixie).

Logs before: notice no chunk is being requested from TTS for a long time.
![Screenshot 2023-11-15 at 9 47 08 AM](https://github.com/fixie-ai/ai-jsx/assets/5062458/4f9360c8-b422-42ac-9b34-09d728132a35)

Logs after: TTS being called before actual content is ready, though it's still not easy to understand what's happening underneath when simply listening to it (there's no gap between filler TTS end and start of actual content).
![Screenshot 2023-11-15 at 9 43 31 AM](https://github.com/fixie-ai/ai-jsx/assets/5062458/4dc2d442-f4b7-4d2b-8abf-e64763c82f9b)
