### PR TITLE
Introduce transcript newlines for function calls/responses

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/examples/test/core/render.tsx
+++ b/packages/examples/test/core/render.tsx
@@ -1,0 +1,34 @@
+import * as AI from 'ai-jsx';
+
+it('ensures that unbatched synchronous are not batched', async () => {
+  async function* MyComponent() {
+    yield '1';
+    yield '2';
+    return '3';
+  }
+
+  const ctx = AI.createRenderContext();
+  const renderResult = ctx.render(<MyComponent />, { batchFrames: false });
+  const frames: string[] = [];
+  for await (const frame of renderResult) {
+    frames.push(frame);
+  }
+  expect(frames).toEqual(['1', '2']);
+  expect(await renderResult).toBe('3');
+});
+
+it('ensures that synchronous updates are batched', async () => {
+  async function* MyComponent() {
+    yield '1';
+    yield '2';
+    return '3';
+  }
+
+  const ctx = AI.createRenderContext();
+  const renderResult = ctx.render(<MyComponent />, { batchFrames: true });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of renderResult) {
+    throw new Error('Render updates should be batched');
+  }
+  expect(await renderResult).toBe('3');
+});

--- a/packages/examples/test/core/render.tsx
+++ b/packages/examples/test/core/render.tsx
@@ -1,6 +1,6 @@
 import * as AI from 'ai-jsx';
 
-it('ensures that unbatched synchronous are not batched', async () => {
+it('ensures that synchronous updates are not batched when batchFrames is false', async () => {
   async function* MyComponent() {
     yield '1';
     yield '2';
@@ -17,7 +17,7 @@ it('ensures that unbatched synchronous are not batched', async () => {
   expect(await renderResult).toBe('3');
 });
 
-it('ensures that synchronous updates are batched', async () => {
+it('ensures that synchronous updates are batched when batchFrames is true', async () => {
   async function* MyComponent() {
     yield '1';
     yield '2';

--- a/packages/fixie-sdk/.eslintrc.cjs
+++ b/packages/fixie-sdk/.eslintrc.cjs
@@ -15,7 +15,10 @@ module.exports = {
 
   rules: {
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true, argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { ignoreRestSiblings: true, argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
 
     'no-undef': 'off',
     'no-magic-numbers': 'off',

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fixieai/sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",

--- a/packages/fixie-sdk/package.json
+++ b/packages/fixie-sdk/package.json
@@ -21,7 +21,7 @@
     "fixie-serve-bin": "dist/fixie-serve-bin.js"
   },
   "peerDependencies": {
-    "ai-jsx": ">=0.17.3 <1.0.0"
+    "ai-jsx": ">=0.27.0 <1.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.6.0",

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -71,7 +71,10 @@ async function serve({
           <Handler {...(invokeAgentRequest.parameters ?? {})} />
         </FixieRequestWrapper>
       );
-      const generator = createRenderContext({ enableOpenTelemetry: true }).render(renderable)[Symbol.asyncIterator]();
+
+      // Enable frame batching to run ahead as aggressively as possible and ensure we don't have frame tearing. (See MessageState.)
+      const renderResult = createRenderContext({ enableOpenTelemetry: true }).render(renderable, { batchFrames: true });
+      const generator = renderResult[Symbol.asyncIterator]();
       return res
         .status(200)
         .type('application/jsonl')
@@ -79,15 +82,10 @@ async function serve({
           Readable.from(
             (async function* () {
               let lastMessages = [];
-              let currentValue = undefined as string | undefined;
               while (true) {
+                let currentValue = undefined as string | undefined;
                 try {
                   const next = await generator.next();
-                  if (!next.done && currentValue == next.value) {
-                    // No change, don't send anything.
-                    continue;
-                  }
-
                   currentValue = next.value;
                   lastMessages = currentValue
                     .split('\n')

--- a/packages/fixie-sdk/src/fixie-serve-bin.tsx
+++ b/packages/fixie-sdk/src/fixie-serve-bin.tsx
@@ -79,10 +79,15 @@ async function serve({
           Readable.from(
             (async function* () {
               let lastMessages = [];
+              let currentValue = undefined as string | undefined;
               while (true) {
-                let currentValue = undefined as string | undefined;
                 try {
                   const next = await generator.next();
+                  if (!next.done && currentValue == next.value) {
+                    // No change, don't send anything.
+                    continue;
+                  }
+
                   currentValue = next.value;
                   lastMessages = currentValue
                     .split('\n')

--- a/packages/fixie-sdk/src/request-wrapper.tsx
+++ b/packages/fixie-sdk/src/request-wrapper.tsx
@@ -14,7 +14,13 @@ export const RequestContext = AI.createContext<{
 } | null>(null);
 
 /**
- * Renders to "in-progress" while the children are still being rendered, and "done" when they're done.
+ * Renders to "in-progress" while `children` is still being rendered, and "done" when it's done.
+ *
+ * `children` should already be memoized to ensure that it's only rendered once.
+ *
+ * To ensure that this component renders consistently with `children`, a render containing both
+ * nodes MUST use frame batching. Without it, there will be frames where the result of this component
+ * will be inconsistent with the component whose rendering it's tracking.
  */
 async function* MessageState({ children }: { children: AI.Node }, { render }: AI.ComponentContext) {
   const renderResult = render(children);

--- a/packages/fixie-sdk/src/request-wrapper.tsx
+++ b/packages/fixie-sdk/src/request-wrapper.tsx
@@ -19,7 +19,7 @@ export const RequestContext = AI.createContext<{
 async function* MessageState({ children }: { children: AI.Node }, { render }: AI.ComponentContext) {
   const renderResult = render(children);
   let didYield = false;
-  for await (const frame of renderResult) {
+  for await (const _ of renderResult) {
     if (!didYield) {
       didYield = true;
       yield 'in-progress';

--- a/packages/fixie-sdk/src/types.ts
+++ b/packages/fixie-sdk/src/types.ts
@@ -23,6 +23,7 @@ export interface FunctionResponseMessage extends MessageBase {
 export interface TextMessage extends MessageBase {
   kind: 'text';
   content: string;
+  state?: 'in-progress' | 'done';
 }
 
 export type Message = FunctionCallMessage | FunctionResponseMessage | TextMessage;

--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -193,8 +193,8 @@ export class ChatRequest {
             // This message is still being generated, so don't include any text after it.
             break;
           } else if (messageState === 'done') {
-            // Append a newline to make clear to the TTS pipeline that the text is complete.
-            currentMessage += '\n';
+            // Append two newlines to end the paragraph (i.e. make clear to the TTS pipeline that the text is complete).
+            currentMessage += '\n\n';
           }
         }
 

--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -183,11 +183,10 @@ export class ChatRequest {
 
       if (!this.done) {
         const currentTurn = isStartConversationRequest ? value.turns.at(-1) : value;
-        const currentMessage = currentTurn.messages
-          .filter((m: any) => m.kind === 'text')
-          .map((m: any) => m.content)
-          .join(' ');
 
+        // Map non-text fragments to empty strings so that they don't appear in the transcript,
+        // but still introduce newlines to make clear that any earlier content is complete.
+        const currentMessage = currentTurn.messages.map((m: any) => (m.kind === 'text' ? m.content : '')).join('\n');
         if (currentMessage === this.outMessage) {
           continue;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,7 +3102,7 @@ __metadata:
     typescript: ^5.1.3
     yargs: ^17.7.2
   peerDependencies:
-    ai-jsx: ">=0.17.3 <1.0.0"
+    ai-jsx: ">=0.27.0 <1.0.0"
   bin:
     fixie-serve-bin: dist/fixie-serve-bin.js
   languageName: unknown


### PR DESCRIPTION
The TTS buffer only gets flushed when it sees content after a sentence. To ensure that it gets flushed after any pre-function-call filler text, this change:
 - Adds the `batchFrames` render option to ai-jsx to coalesce updates from different parts of the render tree. (This delays surfacing frames until further rendering is blocked on I/O.)
 - Adds message-level state tracking (`"in-progress" | "done"`) in `fixie-sdk` to text messages
 - Changes the fixie backend in the voice demo to emit newlines after `"done"` text messages
 - Stops appending text after `"in-progress"` text messages