### PR TITLE
Improve prompt/completion logging

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -241,7 +241,7 @@ function toConversationMessages(partialRendering: AI.PartiallyRendered[]): Conve
 async function loggableMessage(
   message: ConversationMessage,
   render: AI.RenderContext['render'],
-  measureCost?: (message: ConversationMessage, render: AI.ComponentContext['render']) => Promise<number>
+  cost?: (message: ConversationMessage, render: AI.ComponentContext['render']) => Promise<number>
 ) {
   let textPromise: PromiseLike<string> | undefined = undefined;
   switch (message.type) {
@@ -261,11 +261,13 @@ async function loggableMessage(
     }
   }
 
-  const costPromise = measureCost?.(message, render);
-  const loggableProps = { ...message.element.props };
-  if ('children' in loggableProps) {
-    delete loggableProps.children;
-  }
+  const costPromise = cost?.(message, render);
+
+  const { children, ...propsWithoutChildren } = {
+    children: undefined,
+    ...message.element.props,
+  };
+  const loggableProps: Record<string, Jsonifiable> = propsWithoutChildren;
 
   return {
     // Use a function so that it doesn't serialize to JSON, but can be accessed if needed.

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.27.1
+## 0.28.0
+
+- Improved completion/prompt logging to include explicit message text
+
+## [0.27.1](https://github.com/fixie-ai/ai-jsx/commit/b5e436615df37c7b68986059892d6043b684df18)
 
 - Fix bug where memoized components could duplicate content
 - Refactor `<Converse>` to allow rounds to progress in parallel when content allows

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -104,8 +104,14 @@ describe('OpenTelemetry', () => {
           "ai.jsx.tree": ""opentel response from OpenAI"",
         },
         {
-          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=3>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
-          "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=1>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
+          "ai.jsx.memoized": true,
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "Stream",
+          "ai.jsx.tree": ""opentel response from OpenAI"",
+        },
+        {
+          "ai.jsx.completion": "[{"type":"assistant","props":{},"text":"opentel response from OpenAI","cost":10}]",
+          "ai.jsx.prompt": "[{"type":"user","props":{},"text":"hello","cost":4}]",
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "OpenAIChatModel",
           "ai.jsx.tree": "<OpenAIChatModel model="gpt-3.5-turbo">
@@ -174,6 +180,14 @@ describe('OpenTelemetry', () => {
       </UserMessage>",
         },
         {
+          "ai.jsx.memoized": true,
+          "ai.jsx.result": "hello",
+          "ai.jsx.tag": "UserMessage",
+          "ai.jsx.tree": "<UserMessage @memoizedId=1>
+        {"hello"}
+      </UserMessage>",
+        },
+        {
           "ai.jsx.result": "hello",
           "ai.jsx.tag": "UserMessage",
           "ai.jsx.tree": "<UserMessage @memoizedId=1>
@@ -219,6 +233,7 @@ describe('OpenTelemetry', () => {
           "ai.jsx.tree": ""opentel response from OpenAI"",
         },
         {
+          "ai.jsx.memoized": true,
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "AssistantMessage",
           "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
@@ -226,8 +241,15 @@ describe('OpenTelemetry', () => {
       </AssistantMessage>",
         },
         {
-          "ai.jsx.completion": "[{"element":"<AssistantMessage @memoizedId=3>\\n  {\\"opentel response from OpenAI\\"}\\n</AssistantMessage>","cost":10}]",
-          "ai.jsx.prompt": "[{"element":"<UserMessage @memoizedId=1>\\n  {\\"hello\\"}\\n</UserMessage>","cost":4}]",
+          "ai.jsx.result": "opentel response from OpenAI",
+          "ai.jsx.tag": "AssistantMessage",
+          "ai.jsx.tree": "<AssistantMessage @memoizedId=3>
+        {"opentel response from OpenAI"}
+      </AssistantMessage>",
+        },
+        {
+          "ai.jsx.completion": "[{"type":"assistant","props":{},"text":"opentel response from OpenAI","cost":10}]",
+          "ai.jsx.prompt": "[{"type":"user","props":{},"text":"hello","cost":4}]",
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "OpenAIChatModel",
           "ai.jsx.tree": "<OpenAIChatModel model="gpt-3.5-turbo">


### PR DESCRIPTION
Currently the prompt/completion log events include debug-serialized JSX. But this is a) difficult to extract data from and b) unnecessarily generic because we're already working with a very finite set of conversation components.

This changes the structure to include the final text and props (sans-`children`) instead. Additionally, we include a `getElement()` function so that consumers have the option to access the element itself, without it being JSON-serialized by default.