### PR TITLE
Add openai.finish_reason span attribute for OpenAIChatModel

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -568,7 +568,7 @@ export async function* OpenAIChatModel(
 
     logger.trace({ deltaMessage: next.value }, 'Got delta message');
 
-    if (next.value.choices[0].finish_reason !== null) {
+    if (next.value.choices[0].finish_reason) {
       logger.setAttribute('openai.finish_reason', next.value.choices[0].finish_reason);
     }
     return next.value.choices[0].delta;

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -567,6 +567,10 @@ export async function* OpenAIChatModel(
     } while (next.value.choices.length == 0);
 
     logger.trace({ deltaMessage: next.value }, 'Got delta message');
+
+    if (next.value.choices[0].finish_reason !== null) {
+      logger.setAttribute('openai.finish_reason', next.value.choices[0].finish_reason);
+    }
     return next.value.choices[0].delta;
   }
 

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -672,10 +672,13 @@ export async function* OpenAIChatModel(
     }
   }
 
-  // Render the completion conversation to log it.
+  // TS doesn't realize that the advance closure can set `finishReason`.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (finishReason) {
     logger.setAttribute('openai.finish_reason', finishReason);
   }
+
+  // Render the completion conversation to log it.
   await renderToConversation(outputMessages, render, logger, 'completion', tokenCountForConversationMessage);
   return AI.AppendOnlyStream;
 }

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -546,6 +546,7 @@ export async function* OpenAIChatModel(
 
     throw ex;
   }
+  let finishReason: string | undefined = undefined;
   const iterator = chatResponse[Symbol.asyncIterator]();
 
   // We have a single response iterator, but we'll wrap tokens _within_ the structure of <AssistantMessage> or <FunctionCall>
@@ -569,7 +570,7 @@ export async function* OpenAIChatModel(
     logger.trace({ deltaMessage: next.value }, 'Got delta message');
 
     if (next.value.choices[0].finish_reason) {
-      logger.setAttribute('openai.finish_reason', next.value.choices[0].finish_reason);
+      finishReason = next.value.choices[0].finish_reason;
     }
     return next.value.choices[0].delta;
   }
@@ -672,6 +673,9 @@ export async function* OpenAIChatModel(
   }
 
   // Render the completion conversation to log it.
+  if (finishReason) {
+    logger.setAttribute('openai.finish_reason', finishReason);
+  }
   await renderToConversation(outputMessages, render, logger, 'completion', tokenCountForConversationMessage);
   return AI.AppendOnlyStream;
 }

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.28.0
+## 0.28.1
+
+- Add `openai.finish_reason` span attribute for `OpenAIChatModel`
+
+## [0.28.0](https://github.com/fixie-ai/ai-jsx/commit/73251358a1121c98e9059c57d3c905b6156447c4)
 
 - Improved completion/prompt logging to include explicit message text
 

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -92,7 +92,6 @@ describe('OpenTelemetry', () => {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "Stream",
           "ai.jsx.tree": ""▮"",
-          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",
@@ -200,7 +199,6 @@ describe('OpenTelemetry', () => {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "Stream",
           "ai.jsx.tree": ""▮"",
-          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -92,6 +92,7 @@ describe('OpenTelemetry', () => {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "Stream",
           "ai.jsx.tree": ""▮"",
+          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",
@@ -119,6 +120,7 @@ describe('OpenTelemetry', () => {
           {"hello"}
         </UserMessage>
       </OpenAIChatModel>",
+          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",
@@ -198,6 +200,7 @@ describe('OpenTelemetry', () => {
           "ai.jsx.result": "opentel response from OpenAI",
           "ai.jsx.tag": "Stream",
           "ai.jsx.tree": ""▮"",
+          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",
@@ -257,6 +260,7 @@ describe('OpenTelemetry', () => {
           {"hello"}
         </UserMessage>
       </OpenAIChatModel>",
+          "openai.finish_reason": "stop",
         },
         {
           "ai.jsx.result": "opentel response from OpenAI",

--- a/packages/examples/test/lib/openai.tsx
+++ b/packages/examples/test/lib/openai.tsx
@@ -21,7 +21,7 @@ describe('OpenAIChatModel', () => {
                   }),
                 ]);
 
-                yield { choices: [{ delta: { role: 'assistant', content: 'Hi!' } }] };
+                yield { choices: [{ delta: { role: 'assistant', content: 'Hi!' }, finish_reason: 'stop' }] };
               },
             },
           },


### PR DESCRIPTION
This adds an attribute (`openai.finish_reason`) that `OpenAIChatModel` uses to indicate how the stream ended.