### PR TITLE
Bugfix: removing partial unicode when streaming

### DIFF
--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -648,9 +648,16 @@ export async function* OpenAIChatModel(
               argsJson += toolCall.function.arguments;
             }
 
-            yield (
-              <FunctionCall id={id} partial name={name} args={JSON.parse(patchedUntruncateJson(argsJson || '{}'))} />
-            );
+            try {
+              yield (
+                <FunctionCall id={id} partial name={name} args={JSON.parse(patchedUntruncateJson(argsJson || '{}'))} />
+              );
+            } catch (e: any) {
+              // If the JSON is incomplete and we get an error, we can ignore it.
+              if (!('Unexpected string in JSON' in e.message || 'Unexpected end of JSON input' in e.message)) {
+                throw e;
+              }
+            }
 
             delta = await advance();
           }

--- a/packages/ai-jsx/src/lib/util.ts
+++ b/packages/ai-jsx/src/lib/util.ts
@@ -36,4 +36,9 @@ export function getEnvVar(name: string, shouldThrow: boolean = true) {
  * There's an ESM issue with untruncate-json, so we need to do this to support running on both client & server.
  */
 /** @hidden */
-export const patchedUntruncateJson = 'default' in untruncateJson ? untruncateJson.default : untruncateJson;
+const _patchedUntruncateJson = 'default' in untruncateJson ? untruncateJson.default : untruncateJson;
+
+export function patchedUntruncateJson(str: string) {
+  // Remove partial unicode characters: e.g. "\\u5728\\u5fA" -> "\\u5728"
+  return _patchedUntruncateJson(str).replace(/\u[\dA-F]{0,3}[^\dA-F]/gi, '');
+}


### PR DESCRIPTION
Bugfix for [issue reported on Discord](https://discord.com/channels/1065011484125569147/1177574981446684732):
Partially streaming Chinese (and other unicode) characters could cause an error when calling `JSON.parse`. This PR fixes improves the `untruncateJson` to also truncate such cases.
As an extra measure (possibly unneeded), I added a try/catch around `JSON.parse` while streaming so that it doesn't throw an error. This will simply lead to the frame being skipped and no information should be lost.