### PR TITLE
Handle latency values from WebRTC worker

### DIFF
--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -513,7 +513,7 @@ export class LocalChatManager implements ChatManager {
    * Handle the end of playout from the TTS.
    */
   private handlePlaybackComplete() {
-    if (this._state != ChatManagerState.SPEAKING) return;    
+    if (this._state != ChatManagerState.SPEAKING) return;
     this.micManager.isEnabled = true;
     this.changeState(ChatManagerState.LISTENING);
   }
@@ -700,9 +700,9 @@ export class WebRtcChatManager implements ChatManager {
         this.changeState(newState);
       }
     } else if (data.type === 'transcript') {
-      this.handleInputChange(data.transcript); 
+      this.handleInputChange(data.transcript);
     } else if (data.type === 'output') {
-      this.handleOutputChange(data.text, data.final);   
+      this.handleOutputChange(data.text, data.final);
     } else if (data.type == 'latency') {
       this.handleLatency(data.kind, data.value);
     }

--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -704,7 +704,7 @@ export class WebRtcChatManager implements ChatManager {
     } else if (data.type === 'output') {
       this.handleOutputChange(data.text, data.final);   
     } else if (data.type == 'latency') {
-      this.handleLatency(data.kind, data.latency);
+      this.handleLatency(data.kind, data.value);
     }
   }
   private handleInputChange(transcript: Transcript) {
@@ -716,9 +716,9 @@ export class WebRtcChatManager implements ChatManager {
     console.log(`[chat] output: ${text}`);
     this.onOutputChange?.(text, final);
   }
-  private handleLatency(kind: string, latency: number) {
-    console.log(`[chat] latency: ${kind} ${latency.toFixed(0)} ms`);
-    this.onLatencyChange?.(kind, latency);
+  private handleLatency(kind: string, value: number) {
+    console.log(`[chat] latency: ${kind} ${value.toFixed(0)} ms`);
+    this.onLatencyChange?.(kind, value);
   }
 }
 

--- a/packages/voice/src/app/agent/page.tsx
+++ b/packages/voice/src/app/agent/page.tsx
@@ -266,7 +266,7 @@ const AgentPageComponent: React.FC = () => {
       }
     };
     manager.onInputChange = (text, final) => {
-      setInput(text);     
+      setInput(text);
     };
     manager.onOutputChange = (text, final) => {
       setOutput(text);

--- a/packages/voice/src/app/agent/page.tsx
+++ b/packages/voice/src/app/agent/page.tsx
@@ -265,27 +265,33 @@ const AgentPageComponent: React.FC = () => {
           setHelpText(idleText);
       }
     };
-    manager.onInputChange = (text, final, latency) => {
-      setInput(text);
-      if (final && latency) {
-        setAsrLatency(latency);
-        setLlmResponseLatency(0);
-        setLlmTokenLatency(0);
-        setTtsLatency(0);
-      }
+    manager.onInputChange = (text, final) => {
+      setInput(text);     
     };
-    manager.onOutputChange = (text, final, latency) => {
+    manager.onOutputChange = (text, final) => {
       setOutput(text);
       if (final) {
         setInput('');
       }
-      setLlmResponseLatency((prev) => (prev ? prev : latency));
     };
-    manager.onAudioGenerate = (latency) => {
-      setLlmTokenLatency(latency);
-    };
-    manager.onAudioStart = (latency) => {
-      setTtsLatency(latency);
+    manager.onLatencyChange = (kind, latency) => {
+      switch (kind) {
+        case 'asr':
+          setAsrLatency(latency);
+          setLlmResponseLatency(0);
+          setLlmTokenLatency(0);
+          setTtsLatency(0);
+          break;
+        case 'llm':
+          setLlmResponseLatency(latency);
+          break;
+        case 'llmt':
+          setLlmTokenLatency(latency);
+          break;
+        case 'tts':
+          setTtsLatency(latency);
+          break;
+      }
     };
     manager.onError = () => {
       manager.stop();


### PR DESCRIPTION
This updates both the local and WebRTC chat managers to handle latency the same way - it's reported explicitly by the manager, rather than having to be inferred from the various callbacks.