### PR TITLE
Fix restarting chat when using webRTC.

### DIFF
--- a/packages/voice/src/app/agent/chat.tsx
+++ b/packages/voice/src/app/agent/chat.tsx
@@ -671,6 +671,8 @@ export class WebRtcChatManager implements ChatManager {
   }
   private handleSocketClose(event: CloseEvent) {
     console.log(`[chat] socket closed, code=${event.code}, reason=${event.reason}`);
+    // This client is worthless without a connection, so go ahead and reconnect immediately.
+    this.warmup();
   }
   private handleTrackSubscribed(track: RemoteTrack) {
     console.log(`[chat] subscribed to remote audio track ${track.sid}`);


### PR DESCRIPTION
The "End Chat" button currently breaks connections.  Ultimately we should maintain these connections instead, but the server is currently built to assume one conversation per connection also, so the quick fix is to just establish a new connection.