### PR TITLE
Change function parameters to be JSON Schema

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -381,6 +381,7 @@
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/api-logs": "^0.41.1",
     "@ozymandiasthegreat/vad": "^2.0.7",
+    "@types/json-schema": "^7.0.15",
     "axios": "^1.4.0",
     "cli-highlight": "^2.1.11",
     "cli-spinners": "^2.9.0",

--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.28.2",
+  "version": "0.29.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/batteries/docs.tsx
+++ b/packages/ai-jsx/src/batteries/docs.tsx
@@ -669,11 +669,14 @@ export class FixieCorpus<ChunkMetadata extends Jsonifiable = Jsonifiable> implem
     return {
       description,
       parameters: {
-        query: {
-          description: 'The search query. It will be embedded and used in a vector search against the corpus.',
-          type: 'string',
-          required: true,
+        type: 'object',
+        properties: {
+          query: {
+            description: 'The search query. It will be embedded and used in a vector search against the corpus.',
+            type: 'string',
+          },
         },
+        required: ['query'],
       },
       func: async function FixieCorpusQuery({ query }: { query: string }, { getContext }) {
         const corpus = new FixieCorpus(corpusId, getContext(FixieAPIContext));

--- a/packages/ai-jsx/src/batteries/sidekick/platform/large-response-handler.tsx
+++ b/packages/ai-jsx/src/batteries/sidekick/platform/large-response-handler.tsx
@@ -189,11 +189,14 @@ export function redactedFunctionTools(messages: ConversationMessage[]): UseTools
     loadBySimilarity: {
       description: 'Query the response of the "latest redacted function call" by using semantic similarity search.',
       parameters: {
-        query: {
-          type: 'string',
-          description: 'A query string.',
-          required: true,
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'A query string.',
+          },
         },
+        required: ['query'],
       },
       func: ({ query }) => (
         <RerankerFormatted

--- a/packages/ai-jsx/src/batteries/use-tools.tsx
+++ b/packages/ai-jsx/src/batteries/use-tools.tsx
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { ChatCompletion, FunctionParameters, FunctionResponse } from '../core/completion.js';
+import { ChatCompletion, FunctionDefinition, FunctionResponse } from '../core/completion.js';
 import { Component, ComponentContext, Node, RenderContext } from '../index.js';
 import { ConversationMessage, Converse, renderToConversation } from '../core/conversation.js';
 import _ from 'lodash';
@@ -12,17 +12,7 @@ import _ from 'lodash';
 /**
  * Represents a tool that can be provided for the Large Language Model.
  */
-export interface Tool {
-  /**
-   * A description of what the tool does.
-   */
-  description: string;
-
-  /**
-   * A map of parameter names to their description and type.
-   */
-  parameters: FunctionParameters;
-
+export interface Tool extends FunctionDefinition {
   /**
    * A function that invokes the tool.
    *
@@ -32,7 +22,6 @@ export interface Tool {
    * can return a `string` or any AI.JSX {@link Node}, synchronously or
    * asynchronously.
    */
-  // Can we use Zod to do better than any?
   func: Component<any>;
 }
 
@@ -54,13 +43,6 @@ export interface UseToolsProps {
    * Whether the result should include intermediate steps, for example, the execution of the function and its response.
    */
   showSteps?: boolean;
-
-  /**
-   * User data the AI can use to determine what parameters to invoke the tool with.
-   *
-   * For instance, if the user's query can be "what's the weather like at my current location", you might pass `userData` as { "location": "Seattle" }.
-   */
-  userData?: string;
 }
 
 /**
@@ -102,7 +84,7 @@ export async function ExecuteFunction<T>(
  *  // Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
  *  async function activeScene({sceneName}: {sceneName: string}) { ... Code to activate a scene ... }
  *
- *  import z from 'zod';
+
  *  const tools: Record<string, Tool> = {
  *    turnLightsOn: {
  *      description: "Turn the lights on in the user's home",
@@ -117,11 +99,14 @@ export async function ExecuteFunction<T>(
  *    activeScene: {
  *      description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
  *      parameters: {
- *        sceneName: {
- *          description: "The scene to activate the lighting in.",
- *          type: "string",
- *          required: true,
+ *        type: "object",
+ *        properties: {
+ *          sceneName: {
+ *            description: "The scene to activate the lighting in.",
+ *            type: "string",
+ *           },
  *        },
+ *        required: ["sceneName"],
  *      },
  *      func: activeScene,
  *    },

--- a/packages/ai-jsx/src/lib/openai.tsx
+++ b/packages/ai-jsx/src/lib/openai.tsx
@@ -10,7 +10,6 @@ import {
   FunctionDefinition,
   ModelProps,
   ModelPropsWithChildren,
-  getParametersSchema,
 } from '../core/completion.js';
 import { AssistantMessage, ConversationMessage, FunctionCall, renderToConversation } from '../core/conversation.js';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
@@ -508,7 +507,7 @@ export async function* OpenAIChatModel(
           function: {
             name: functionName,
             description: functionDefinition.description,
-            parameters: getParametersSchema(functionDefinition.parameters),
+            parameters: functionDefinition.parameters as Record<string, unknown>,
           },
           type: 'function',
         })

--- a/packages/docs/docs/ai-newcomers.md
+++ b/packages/docs/docs/ai-newcomers.md
@@ -110,19 +110,21 @@ In AI.JSX, this looks like:
 /**
  * Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".
  */
-async function activateScene({sceneName}: {sceneName: string}) {}
+async function activateScene({ sceneName }: { sceneName: string }) {}
 
 // Describe to the LLM what's available
-import z from 'zod';
 const tools: Record<string, Tool> = {
   activateScene: {
     description: `Activate a scene in the user's lighting settings, like "Bedtime" or "Midday".`,
-    parameters: parameters: {
-      sceneName: {
-        description: "The scene to activate the lighting in.",
-        type: "string",
-        required: true,
+    parameters: {
+      type: 'object',
+      properties: {
+        sceneName: {
+          description: 'The scene to activate the lighting in.',
+          type: 'string',
+        },
       },
+      required: ['sceneName'],
     },
     func: activateScene,
   },

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.28.2
+## 0.30.0
+
+- Changed the `FunctionDefinition` and `Tool` types to explicit JSON Schema. Zod types must now be explicitly
+  converted to JSON Schema, and the `required` semantics now match JSON Schema.
+
+## [0.28.2](https://github.com/fixie-ai/ai-jsx/tree/524cf2d69eb63426a098723997e39f0dda5a37c2)
 
 - Fix bug where partially streamed unicode characters (e.g. Chinese) would cause an error in OpenAI function calls.
 

--- a/packages/docs/docs/tutorials/aijsxTutorials/part7-tools.md
+++ b/packages/docs/docs/tutorials/aijsxTutorials/part7-tools.md
@@ -21,22 +21,28 @@ const tools = {
   checkStockPrice: {
     description: 'Check the price of a stock.',
     parameters: {
-      symbol: {
-        description: 'The symbol of the stock to get price for.',
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        symbol: {
+          description: 'The symbol of the stock to get price for.',
+          type: 'string',
+        },
       },
+      required: ['symbol'],
     },
     func: checkStockPrice,
   },
   getHistoricalPrices: {
     description: 'Return historical prices for a stock.',
     parameters: {
-      symbol: {
-        description: 'The symbol of the stock to get price for.',
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        symbol: {
+          description: 'The symbol of the stock to get price for.',
+          type: 'string',
+        },
       },
+      required: ['symbol'],
     },
     func: getHistoricalPrices,
   },

--- a/packages/examples/src/eval-model-timing.tsx
+++ b/packages/examples/src/eval-model-timing.tsx
@@ -3,17 +3,19 @@ import { Tool, UseTools } from 'ai-jsx/batteries/use-tools';
 import { UserMessage, SystemMessage } from 'ai-jsx/core/conversation';
 import { LogImplementation, LogLevel } from 'ai-jsx/core/log';
 import { OpenAI, ValidChatModel } from 'ai-jsx/lib/openai';
-import z from 'zod';
 
 export const tools: Record<string, Tool> = {
   lookUpAcmeCorpKnowledgeBase: {
     description: 'Look up information about Acme Corp from its customer support and developer docs',
     parameters: {
-      query: {
-        description: 'The search query. It will be embedded and used in a vector search against the corpus.',
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        query: {
+          description: 'The search query. It will be embedded and used in a vector search against the corpus.',
+          type: 'string',
+        },
       },
+      required: ['query'],
     },
     func: () => null,
   },
@@ -24,82 +26,81 @@ export const tools: Record<string, Tool> = {
   },
   printJson: {
     description: 'Print a JSON response',
-    // @ts-expect-error
-    parameters: z.record(z.unknown()),
+    parameters: {},
     func: () => null,
   },
   listConversations: {
     description: 'List conversations for a mailbox. Each conversation result is summarized.',
-    parameters: z.object({
-      embed: z.string().optional().describe('Allows embedding/loading of sub-entities, allowed values are: threads'),
-      mailbox: z
-        .number()
-        .optional()
-        .describe('Filters conversations from a specific mailbox id. Use comma separated values for more mailboxes'),
-      status: z
-        .union([
-          z.literal('active'),
-          z.literal('all'),
-          z.literal('closed'),
-          z.literal('open'),
-          z.literal('pending'),
-          z.literal('spam'),
-        ])
-        .optional()
-        .describe('Filter conversation by status (defaults to active)'),
-      tag: z.string().optional().describe('Filter conversation by tags. Use comma separated values for more tags'),
-      assigned_to: z.number().optional().describe('Filters conversations by assignee id'),
-      modifiedSince: z
-        .string()
-        .optional()
-        .describe('Filters conversations modified after this timestamp, e.g. 2018-05-04T12:00:03Z'),
-      number: z.number().optional().describe('Looks up conversation by conversation number'),
-      sortField: z
-        .union([
-          z.literal('createdAt'),
-          z.literal('customerEmail'),
-          z.literal('customerName'),
-          z.literal('mailboxid'),
-          z.literal('modifiedAt'),
-          z.literal('number'),
-          z.literal('score'),
-          z.literal('status'),
-          z.literal('subject'),
-          z.literal('waitingSince'),
-        ])
-        .optional()
-        .describe('Sorts the result by specified field'),
-      sortOrder: z
-        .union([z.literal('desc'), z.literal('asc')])
-        .optional()
-        .describe('Sort order. Default is desc'),
-      page: z.number().optional().describe('Page number'),
-    }),
+    parameters: {
+      type: 'object',
+      properties: {
+        embed: { type: 'string', description: 'Allows embedding/loading of sub-entities, allowed values are: threads' },
+        mailbox: {
+          type: 'number',
+          description:
+            'Filters conversations from a specific mailbox id. Use comma separated values for more mailboxes',
+        },
+        status: {
+          type: 'string',
+          enum: ['active', 'all', 'closed', 'open', 'pending', 'spam'],
+          description: 'Filter conversation by status (defaults to active)',
+        },
+        tag: { type: 'string', description: 'Filter conversation by tags. Use comma separated values for more tags' },
+        assignedTo: { type: 'number', description: 'Filters conversations by assignee id' },
+        modifiedSince: {
+          type: 'string',
+          description: 'Filters conversations modified after this timestamp, e.g. 2018-05-04T12:00:03Z',
+        },
+        number: { type: 'number', description: 'Looks up conversation by conversation number' },
+        sortField: {
+          type: 'string',
+          enum: [
+            'createdAt',
+            'customerEmail',
+            'customerName',
+            'mailboxid',
+            'modifiedAt',
+            'number',
+            'score',
+            'status',
+            'subject',
+            'waitingSince',
+          ],
+          description: 'Sorts the result by specified field',
+        },
+        sortOrder: { type: 'string', enum: ['desc', 'asc'], description: 'Sort order. Default is desc' },
+        page: { type: 'number', description: 'Page number' },
+      },
+    },
     func: () => null,
   },
   getConversation: {
     description: 'Get full details for a conversation by ID',
     parameters: {
-      id: {
-        description: 'The ID of the conversation',
-        type: 'number',
-        required: true,
+      type: 'object',
+      properties: {
+        id: {
+          description: 'The ID of the conversation',
+          type: 'number',
+        },
       },
+      required: ['id'],
     },
     func: () => null,
   },
   listUsers: {
     description: 'List users on this Acme Corp plan',
     parameters: {
-      email: {
-        description: 'Optional filter param for looking up users by email using exact match.',
-        type: 'string',
-        required: false,
-      },
-      mailbox: {
-        description: 'Optional filter param for looking up users by mailbox.',
-        type: 'number',
-        required: false,
+      type: 'object',
+      properties: {
+        email: {
+          description: 'Optional filter param for looking up users by email using exact match.',
+          type: 'string',
+        },
+        mailbox: {
+          description: 'Optional filter param for looking up users by mailbox.',
+          type: 'number',
+        },
       },
     },
     func: () => null,
@@ -107,11 +108,13 @@ export const tools: Record<string, Tool> = {
   getUser: {
     description: 'Get a user by ID',
     parameters: {
-      id: {
-        description: 'The ID of the user',
-        type: 'number',
-        required: true,
+      properties: {
+        id: {
+          description: 'The ID of the user',
+          type: 'number',
+        },
       },
+      required: ['id'],
     },
     func: () => null,
   },
@@ -123,49 +126,46 @@ export const tools: Record<string, Tool> = {
     description:
       'The company report provides statistics about your company performance over a given time range. You may optionally specify two time ranges to see how performance changed between the two ranges. Note: The reporting endpoints are only available to Plus and Company plans. Account Owners for Standard plans can add access to these via an add-on.',
     parameters: {
-      start: {
-        description: "Start of the interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        start: {
+          description:
+            "Start of the interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
+          type: 'string',
+        },
+        end: {
+          description: "End of the interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
+          type: 'string',
+        },
+        previousStart: {
+          description:
+            "Start of the previous interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
+          type: 'string',
+        },
+        previousEnd: {
+          description:
+            "End of the previous interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
+          type: 'string',
+        },
+        mailboxes: {
+          description: 'List of comma separated ids to filter on mailboxes',
+          type: 'number',
+        },
+        tags: {
+          description: 'List of comma separated ids to filter on tags',
+          type: 'number',
+        },
+        types: {
+          description: 'List of comma separated conversation types to filter on, valid values are email, chat, phone',
+          type: 'string',
+          enum: ['email', 'chat', 'phone'],
+        },
+        folders: {
+          description: 'List of comma separated folder ids to filter on folders',
+          type: 'number',
+        },
       },
-      end: {
-        description: "End of the interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
-        type: 'string',
-        required: true,
-      },
-      previousStart: {
-        description:
-          "Start of the previous interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
-        type: 'string',
-        required: false,
-      },
-      previousEnd: {
-        description:
-          "End of the previous interval in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss'Z') (e.g. 2019-05-02T12:00:00Z)",
-        type: 'string',
-        required: false,
-      },
-      mailboxes: {
-        description: 'List of comma separated ids to filter on mailboxes',
-        type: 'number',
-        required: false,
-      },
-      tags: {
-        description: 'List of comma separated ids to filter on tags',
-        type: 'number',
-        required: false,
-      },
-      types: {
-        description: 'List of comma separated conversation types to filter on, valid values are email, chat, phone',
-        type: 'string',
-        enum: ['email', 'chat', 'phone'],
-        required: false,
-      },
-      folders: {
-        description: 'List of comma separated folder ids to filter on folders',
-        type: 'number',
-        required: false,
-      },
+      required: ['start', 'end'],
     },
     func: () => null,
   },

--- a/packages/examples/src/sidekick-output-format.tsx
+++ b/packages/examples/src/sidekick-output-format.tsx
@@ -7,11 +7,14 @@ const tools: Record<string, Tool> = {
   lookUpFlight: {
     description: 'Look up a flight',
     parameters: {
-      flightNumber: {
-        description: 'The flight number',
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        flightNumber: {
+          description: 'The flight number',
+          type: 'string',
+        },
       },
+      required: ['flightNumber'],
     },
     func: ({ flightNumber }: { flightNumber: string }) =>
       JSON.stringify({

--- a/packages/examples/src/use-tools.tsx
+++ b/packages/examples/src/use-tools.tsx
@@ -13,11 +13,14 @@ function App({ query }: { query: string }) {
     evaluate_expression: {
       description: 'Evaluates a mathematical expression',
       parameters: {
-        expression: {
-          description: 'The mathematical expression to evaluate',
-          type: 'string',
-          required: true,
+        type: 'object',
+        properties: {
+          expression: {
+            description: 'The mathematical expression to evaluate',
+            type: 'string',
+          },
         },
+        required: ['expression'],
       },
       func: evaluate,
     },

--- a/packages/examples/test/batteries/use-tools.tsx
+++ b/packages/examples/test/batteries/use-tools.tsx
@@ -35,11 +35,14 @@ it('should call a tool', async () => {
             myFunc: {
               description: 'Test tool',
               parameters: {
-                parameter: {
-                  description: 'Test parameter',
-                  type: 'string',
-                  required: true,
+                type: 'object',
+                properties: {
+                  parameter: {
+                    description: 'Test parameter',
+                    type: 'string',
+                  },
                 },
+                required: ['parameter'],
               },
               func: ({ parameter }: { parameter: string }) => parameter.toLocaleUpperCase(),
             },
@@ -88,11 +91,14 @@ it('should give tools access to context', async () => {
               myFunc: {
                 description: 'Test tool',
                 parameters: {
-                  parameter: {
-                    description: 'Test parameter',
-                    type: 'string',
-                    required: true,
+                  type: 'object',
+                  properties: {
+                    parameter: {
+                      description: 'Test parameter',
+                      type: 'string',
+                    },
                   },
+                  required: ['parameter'],
                 },
                 func: MyTool,
               },
@@ -138,11 +144,14 @@ it('should handle failures', async () => {
               myFunc: {
                 description: 'Test tool',
                 parameters: {
-                  parameter: {
-                    description: 'Test parameter',
-                    type: 'string',
-                    required: true,
+                  type: 'object',
+                  properties: {
+                    parameter: {
+                      description: 'Test parameter',
+                      type: 'string',
+                    },
                   },
+                  required: ['parameter'],
                 },
                 func: MyTool,
               },

--- a/packages/examples/test/core/completion.tsx
+++ b/packages/examples/test/core/completion.tsx
@@ -370,12 +370,15 @@ describe('functions', () => {
       myFunc: {
         description: 'My function',
         parameters: {
-          myParam: {
-            description: 'My parameter',
-            type: 'string',
-            enum: ['option1', 'option2'],
-            required: true,
+          type: 'object',
+          properties: {
+            myParam: {
+              description: 'My parameter',
+              type: 'string',
+              enum: ['option1', 'option2'],
+            },
           },
+          required: ['myParam'],
         },
         func: () => undefined,
       },
@@ -423,12 +426,15 @@ describe('functions', () => {
       myFunc: {
         description: 'My function',
         parameters: {
-          myParam: {
-            description: 'My parameter',
-            type: 'string',
-            enum: ['option1', 'option2'],
-            required: true,
+          type: 'object',
+          properties: {
+            myParam: {
+              description: 'My parameter',
+              type: 'string',
+              enum: ['option1', 'option2'],
+            },
           },
+          required: ['myParam'],
         },
         func: () => undefined,
       },

--- a/packages/sidekick-github/src/index.tsx
+++ b/packages/sidekick-github/src/index.tsx
@@ -10,11 +10,14 @@ const tools: Record<string, Tool> = {
   runGithubGraphqlQuery: {
     description: 'Run a GraphQL query against the Github API',
     parameters: {
-      query: {
-        description: 'The GraphQL query to run',
-        type: 'string',
-        required: true,
+      type: 'object',
+      properties: {
+        query: {
+          description: 'The GraphQL query to run',
+          type: 'string',
+        },
       },
+      required: ['query'],
     },
     func: async ({ query }: { query: string }) => {
       const response = await fetch('https://api.github.com/graphql', {

--- a/packages/tutorial/src/tools.tsx
+++ b/packages/tutorial/src/tools.tsx
@@ -31,22 +31,28 @@ function StockAgent(props: { query: string }) {
     checkStockPrice: {
       description: 'Check the price of a stock.',
       parameters: {
-        symbol: {
-          description: 'The stock symbol to check the price of.',
-          type: 'string',
-          required: true,
+        type: 'object' as const,
+        properties: {
+          symbol: {
+            description: 'The symbol of the stock to get price for.',
+            type: 'string' as const,
+          },
         },
+        required: ['symbol'],
       },
       func: checkStockPrice,
     },
     getHistoricalPrices: {
       description: 'Return historical prices for a stock.',
       parameters: {
-        symbol: {
-          description: 'The stock symbol to get historical prices for.',
-          type: 'string',
-          required: true,
+        type: 'object' as const,
+        properties: {
+          symbol: {
+            description: 'The stock symbol to get historical prices for.',
+            type: 'string' as const,
+          },
         },
+        required: ['symbol'],
       },
       func: getHistoricalPrices,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,6 +6166,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.15":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
+  languageName: node
+  linkType: hard
+
 "@types/json5@npm:^0.0.29":
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
@@ -7289,6 +7296,7 @@ __metadata:
     "@types/eslint": ^8
     "@types/jest": ^29.5.2
     "@types/js-yaml": ^4.0.5
+    "@types/json-schema": ^7.0.15
     "@types/lodash": ^4.14.194
     "@types/node": ^20.2.1
     "@types/react": ^18.2.7


### PR DESCRIPTION
Previously the function definitions were typed as either Zod or JSON Schema-ish (with some differences around `required`). Rather than have a layer of conversion logic (`getParametersSchema`) this makes the input types explicitly JSON Schema. This facilitates integration with other types, e.g. OpenAPI specs. (Callers using Zod must now do the conversion themselves, e.g. with `zod-to-json-schema`.)