### PR TITLE
Update AnthropicChatModel, relax OpenAIChatModel

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "volta": {
     "extends": "../../package.json"
   },
@@ -375,7 +375,7 @@
     "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.5.10",
+    "@anthropic-ai/sdk": "^0.20.1",
     "@mdx-js/mdx": "^2.3.0",
     "@nick.heiner/wandb-fork": "^0.5.2-5",
     "@opentelemetry/api": "^1.4.1",

--- a/packages/ai-jsx/src/batteries/constrained-output.tsx
+++ b/packages/ai-jsx/src/batteries/constrained-output.tsx
@@ -323,7 +323,7 @@ export async function* JsonChatCompletionFunctionCall(
       functionDefinitions={{
         print: {
           description: 'Prints the response in a human readable format.',
-          parameters: schema,
+          parameters: schema as any,
         },
       }}
       forcedFunction="print"

--- a/packages/ai-jsx/src/core/completion.tsx
+++ b/packages/ai-jsx/src/core/completion.tsx
@@ -29,6 +29,8 @@ export interface ModelProps {
   maxTokens?: number;
   /** The number of tokens to reserve for the generation. */
   reservedTokens?: number;
+  /** Maximum number of input tokens to allow.  */
+  maxInputTokens?: number;
   /** A list of stop tokens. */
   stop?: string[];
 
@@ -37,6 +39,16 @@ export interface ModelProps {
    *
    * @see https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p */
   topP?: number;
+
+  /**
+   * Any function definitions (tools) that the model can choose to invoke.
+   */
+  functionDefinitions?: Record<string, FunctionDefinition>;
+
+  /**
+   * If specified, the model will be forced to use this function.
+   */
+  forcedFunction?: string;
 }
 
 /**

--- a/packages/ai-jsx/src/lib/anthropic.tsx
+++ b/packages/ai-jsx/src/lib/anthropic.tsx
@@ -2,8 +2,8 @@ import AnthropicSDK from '@anthropic-ai/sdk';
 import { getEnvVar } from './util.js';
 import * as AI from '../index.js';
 import { Node } from '../index.js';
-import { ChatProvider, ModelProps, ModelPropsWithChildren } from '../core/completion.js';
-import { AssistantMessage, ConversationMessage, UserMessage, renderToConversation } from '../core/conversation.js';
+import { ChatProvider, ModelPropsWithChildren } from '../core/completion.js';
+import { AssistantMessage, FunctionCall, renderToConversation } from '../core/conversation.js';
 import { AIJSXError, ErrorCode } from '../core/errors.js';
 import { debugRepresentation } from '../core/debug.js';
 import _ from 'lodash';
@@ -24,21 +24,7 @@ const anthropicClientContext = AI.createContext<() => AnthropicSDK>(
  *
  * @see https://docs.anthropic.com/claude/reference/complete_post.
  */
-export type ValidChatModel =
-  | 'claude-1'
-  | 'claude-1-100k'
-  | 'claude-instant-1'
-  | 'claude-instant-1-100k'
-  | 'claude-1.3'
-  | 'claude-1.3-100k'
-  | 'claude-1.2'
-  | 'claude-1.0'
-  | 'claude-instant-1.2'
-  | 'claude-instant-1.1'
-  | 'claude-instant-1.1-100k'
-  | 'claude-instant-1.0'
-  | 'claude-2'
-  | 'claude-2.0';
+export type ValidChatModel = AnthropicSDK.MessageCreateParamsStreaming['model'];
 
 /**
  * If you use an Anthropic model without specifying the max tokens for the completion, this value will be used as the default.
@@ -58,7 +44,10 @@ export function Anthropic({
   client,
   completionModel,
   ...defaults
-}: { children: Node; client?: AnthropicSDK; chatModel?: ValidChatModel; completionModel?: never } & ModelProps) {
+}: { children: Node; client?: AnthropicSDK; chatModel?: ValidChatModel; completionModel?: never } & Omit<
+  AnthropicChatModelProps,
+  'children' | 'model'
+>) {
   let result = children;
 
   if (client) {
@@ -88,79 +77,270 @@ export function Anthropic({
 
 interface AnthropicChatModelProps extends ModelPropsWithChildren {
   model: ValidChatModel;
+  useBetaTools?: boolean;
 }
 export async function* AnthropicChatModel(
   props: AnthropicChatModelProps,
   { render, getContext, logger, memo }: AI.ComponentContext
 ): AI.RenderableStream {
-  if ('functionDefinitions' in props && props.functionDefinitions) {
+  yield AI.AppendOnlyStream;
+
+  const anthropic = getContext(anthropicClientContext)();
+  const messages = await renderToConversation(props.children, render, logger, 'prompt');
+
+  const legacyModels: Record<string, string> = {
+    'claude-1': 'claude-1.3',
+    'claude-1-100k': 'claude-1.3',
+    'claude-2': 'claude-2.1',
+    'claude-instant-1': 'claude-instant-1.2',
+    'claude-instant-1-100k': 'claude-instant-1.2',
+    'claude-instant-1.1-100k': 'claude-instant-1.1',
+  };
+  const resolvedModel = props.model in legacyModels ? legacyModels[props.model] : props.model;
+  /**
+   * From https://docs.anthropic.com/claude/docs/legacy-model-guide#anthropics-legacy-models
+   * > Our legacy models include Claude Instant 1.2, Claude 2.0, and Claude 2.1. Of these legacy models, Claude 2.1 is the only model with system prompt support (all Claude 3 models have full system prompt support).
+   */
+  const supportsSystemPrompt = !(
+    resolvedModel.startsWith('claude-1') ||
+    resolvedModel.startsWith('claude-instant') ||
+    resolvedModel.startsWith('claude-2.0')
+  );
+  const leadingSystemMessages = _.takeWhile(messages, (m) => supportsSystemPrompt && m.type === 'system');
+  const commonRequestProperties = {
+    system: (await Promise.all(leadingSystemMessages.map((m) => render(m.element)))).join('\n\n') || undefined,
+    model: resolvedModel,
+    max_tokens: props.maxTokens ?? defaultMaxTokens,
+    temperature: props.temperature,
+    stop_sequences: props.stop,
+    top_p: props.topP,
+  };
+
+  type MessageParamWithoutStrings = AnthropicSDK.Beta.Tools.ToolsBetaMessageParam & { content: unknown[] };
+
+  const hasFunctionDefinitions = Object.keys(props.functionDefinitions ?? {}).length > 0;
+  const useBetaTools = props.useBetaTools ?? hasFunctionDefinitions;
+
+  const anthropicMessages: MessageParamWithoutStrings[] = (
+    await Promise.all(
+      messages
+        .slice(leadingSystemMessages.length)
+        .map<Promise<MessageParamWithoutStrings | MessageParamWithoutStrings[]>>(async (m) => {
+          switch (m.type) {
+            case 'user':
+            case 'assistant':
+              return { role: m.type, content: [{ type: 'text', text: await render(m.element) }] };
+            case 'system': {
+              // Polyfill system messages that are either not supported or do not appear at the start of the prompt.
+              const text = await render(m.element);
+              return [
+                {
+                  role: 'user',
+                  content: [
+                    {
+                      type: 'text',
+                      text: `For subsequent replies you will adhere to the following instructions: ${text}`,
+                    },
+                  ],
+                },
+                { role: 'assistant', content: [{ type: 'text', text: 'Okay, I will do that.' }] },
+              ];
+            }
+            case 'functionCall':
+              return {
+                role: 'assistant',
+                content: useBetaTools
+                  ? [
+                      {
+                        type: 'tool_use',
+                        id: m.element.props.id!,
+                        name: m.element.props.name,
+                        input: m.element.props.args,
+                      },
+                    ]
+                  : [
+                      {
+                        type: 'text',
+                        text: await render(
+                          <>
+                            {'<'}function_calls{'>'}
+                            {'\n'}
+                            {'<'}invoke{'>'}
+                            {'\n'}
+                            {'<'}tool_name{'>'}
+                            {m.element.props.name}
+                            {'<'}/tool_name{'>'}
+                            {'\n'}
+                            {'<'}parameters{'>'}
+                            {'\n'}
+                            {Object.entries(m.element.props.args).map(([key, value]) => (
+                              <>
+                                {'<'}
+                                {key}
+                                {'>'}
+                                {value}
+                                {'<'}/{key}
+                                {'>'}
+                                {'\n'}
+                              </>
+                            ))}
+                            {'<'}/parameters{'>'}
+                            {'\n'}
+                            {'<'}/invoke{'>'}
+                            {'\n'}
+                            {'<'}/function_calls{'>'}
+                          </>
+                        ),
+                      },
+                    ],
+              };
+            case 'functionResponse':
+              return {
+                role: 'user',
+                content: useBetaTools
+                  ? [
+                      {
+                        type: 'tool_result',
+                        tool_use_id: m.element.props.id!,
+                        content: [{ type: 'text', text: await render(m.element.props.children) }],
+                        is_error: m.element.props.failed,
+                      },
+                    ]
+                  : [
+                      {
+                        type: 'text',
+                        text: await render(
+                          <>
+                            {'<'}function_results{'>'}
+                            {'\n'}
+                            {'<'}result{'>'}
+                            {'\n'}
+                            {'<'}tool_name{'>'}
+                            {m.element.props.name}
+                            {'<'}/tool_name{'>'}
+                            {'\n'}
+                            {m.element.props.failed ? (
+                              <>
+                                {'<'}error{'>'}
+                                {'\n'}
+                                {m.element.props.children}
+                                {'</'}error{'>'}
+                                {'\n'}
+                              </>
+                            ) : (
+                              <>
+                                {'<'}stdout{'>'}
+                                {'\n'}
+                                {m.element.props.children}
+                                {'\n'}
+                                {'</'}stdout{'>'}
+                                {'\n'}
+                              </>
+                            )}
+                            {'<'}/invoke{'>'}
+                            {'\n'}
+                            {'<'}/function_results{'>'}
+                          </>
+                        ),
+                      },
+                    ],
+              };
+            default:
+              return [] as MessageParamWithoutStrings[];
+          }
+        })
+    )
+  ).flat(1);
+
+  if (props.forcedFunction && props.functionDefinitions && props.forcedFunction in props.functionDefinitions) {
+    const polyfillPrompt: MessageParamWithoutStrings = {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: `Use the \`${props.forcedFunction}\` tool.`,
+        },
+      ],
+    };
+    logger.warn(
+      { forcedFunction: props.forcedFunction, addedUserMessage: polyfillPrompt },
+      'Anthropic does not directly support forced functions. Adding additional user message to prompt.'
+    );
+    anthropicMessages.push(polyfillPrompt);
+  } else if (props.forcedFunction) {
     throw new AIJSXError(
-      'Anthropic does not support function calling, but function definitions were provided.',
+      `The function ${props.forcedFunction} was forced, but no function with that name was defined.`,
+      ErrorCode.ChatCompletionBadInput,
+      'user'
+    );
+  }
+
+  // Combine any adjacent user and assistant messages.
+  const combinedAnthropicMessages: typeof anthropicMessages = [];
+  for (const message of anthropicMessages) {
+    const lastMessage = combinedAnthropicMessages.at(-1);
+    if (lastMessage?.role === message.role) {
+      lastMessage.content.push(...message.content);
+    } else {
+      combinedAnthropicMessages.push(message);
+    }
+  }
+
+  if (useBetaTools) {
+    // If there are tools in the prompt, we need to use the tools API (which currently does not support streaming).
+    const toolsRequest: AnthropicSDK.Beta.Tools.MessageCreateParamsNonStreaming = {
+      messages: combinedAnthropicMessages,
+      tools: Object.entries(props.functionDefinitions ?? {}).map(([functionName, definition]) => ({
+        name: functionName,
+        description: definition.description,
+        input_schema: definition.parameters as any,
+      })),
+      stream: false,
+      ...commonRequestProperties,
+    };
+    logger.debug({ toolsRequest }, 'Calling anthropic.beta.tools.messages.create');
+    try {
+      const result = await anthropic.beta.tools.messages.create(toolsRequest);
+      return result.content.map((contentBlock) =>
+        contentBlock.type === 'text' ? (
+          <AssistantMessage>{contentBlock.text}</AssistantMessage>
+        ) : (
+          <FunctionCall id={contentBlock.id} name={contentBlock.name} args={contentBlock.input as any} />
+        )
+      );
+    } catch (err) {
+      if (err instanceof AnthropicSDK.APIError) {
+        throw new AIJSXError(
+          err.message,
+          ErrorCode.AnthropicAPIError,
+          'runtime',
+          Object.fromEntries(Object.entries(err))
+        );
+      }
+      throw err;
+    }
+  }
+
+  if (hasFunctionDefinitions) {
+    throw new AIJSXError(
+      'Anthropic models only support functions via the beta tools API, but useBetaTools was set to false.',
       ErrorCode.ChatModelDoesNotSupportFunctions,
       'user'
     );
   }
-  yield AI.AppendOnlyStream;
-  const messages = await Promise.all(
-    // TODO: Support token budget/conversation shrinking
-    (
-      await renderToConversation(props.children, render, logger, 'prompt')
-    )
-      .flatMap<Exclude<ConversationMessage, { type: 'system' }>>((message) => {
-        if (message.type === 'system') {
-          return [
-            {
-              type: 'user',
-              element: (
-                <UserMessage>
-                  For subsequent replies you will adhere to the following instructions: {message.element}
-                </UserMessage>
-              ),
-            },
-            { type: 'assistant', element: <AssistantMessage>Okay, I will do that.</AssistantMessage> },
-          ];
-        }
 
-        return [message];
-      })
-      .map(async (message) => {
-        switch (message.type) {
-          case 'user':
-            return `${AnthropicSDK.HUMAN_PROMPT} ${await render(message.element)}`;
-          case 'assistant':
-          case 'functionCall':
-          case 'functionResponse':
-            return `${AnthropicSDK.AI_PROMPT} ${await render(message.element)}`;
-        }
-      })
-  );
-
-  if (!messages.length) {
-    throw new AIJSXError(
-      "ChatCompletion must have at least one child that's UserMessage or AssistantMessage, but no such children were found.",
-      ErrorCode.ChatCompletionMissingChildren,
-      'user'
-    );
-  }
-
-  messages.push(AnthropicSDK.AI_PROMPT);
-
-  const anthropic = getContext(anthropicClientContext)();
-  const anthropicCompletionRequest: AnthropicSDK.CompletionCreateParams = {
-    prompt: messages.join('\n\n'),
-    max_tokens_to_sample: props.maxTokens ?? defaultMaxTokens,
-    temperature: props.temperature,
-    model: props.model,
-    stop_sequences: props.stop,
+  const anthropicCompletionRequest: AnthropicSDK.MessageCreateParamsStreaming = {
+    messages: combinedAnthropicMessages as AnthropicSDK.MessageParam[],
+    ...commonRequestProperties,
     stream: true,
-    top_p: props.topP,
   };
 
-  logger.debug({ anthropicCompletionRequest }, 'Calling createCompletion');
+  logger.debug({ anthropicCompletionRequest }, 'Calling anthropic.messages.create');
 
-  let response: Awaited<ReturnType<typeof anthropic.completions.create>>;
+  const responsePromise = anthropic.messages.create(anthropicCompletionRequest);
+  let response: Awaited<typeof responsePromise>;
   try {
-    response = await anthropic.completions.create(anthropicCompletionRequest);
+    response = await anthropic.messages.create(anthropicCompletionRequest);
   } catch (err) {
     if (err instanceof AnthropicSDK.APIError) {
       throw new AIJSXError(
@@ -178,18 +358,28 @@ export async function* AnthropicChatModel(
   let complete = false;
   const Stream = async function* (): AI.RenderableStream {
     yield AI.AppendOnlyStream;
-    let isFirstResponse = true;
-    for await (const completion of response) {
-      let text = completion.completion;
-      if (isFirstResponse && text.length > 0) {
-        isFirstResponse = false;
-        if (text.startsWith(' ')) {
-          text = text.slice(1);
-        }
+    for await (const deltaEvent of response) {
+      logger.trace({ deltaEvent }, 'Got Anthropic stream event');
+      switch (deltaEvent.type) {
+        case 'message_start':
+        case 'message_stop':
+        case 'content_block_start':
+        case 'content_block_stop':
+          break;
+        case 'message_delta':
+          logger.setAttribute('anthropic.usage', JSON.stringify(deltaEvent.usage));
+          if (deltaEvent.delta.stop_reason) {
+            logger.setAttribute('anthropic.stop_reason', deltaEvent.delta.stop_reason);
+          }
+          break;
+        case 'content_block_delta':
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (deltaEvent.delta.type === 'text_delta') {
+            accumulatedContent += deltaEvent.delta.text;
+            yield deltaEvent.delta.text;
+          }
+          break;
       }
-      accumulatedContent += text;
-      logger.trace({ completion }, 'Got Anthropic stream event');
-      yield text;
     }
 
     complete = true;

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -2,6 +2,11 @@
 
 ## 0.30.0
 
+- Added support for Claude 3 and messages API in `AnthropicChatModel`
+- Relaxed function calling check for `OpenAIChatModel`
+
+## [0.29.0](https://github.com/fixie-ai/ai-jsx/tree/4ce9b17471ff6cd8e3928d189d254dca8e65e9ba)
+
 - Changed the `FunctionDefinition` and `Tool` types to explicit JSON Schema. Zod types must now be explicitly
   converted to JSON Schema, and the `required` semantics now match JSON Schema.
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -72,7 +72,7 @@
     "test": "yarn run typecheck && yarn run unit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.5.10",
+    "@anthropic-ai/sdk": "^0.20.1",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/api-logs": "^0.41.1",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.41.1",

--- a/packages/examples/src/chat-function-call.tsx
+++ b/packages/examples/src/chat-function-call.tsx
@@ -2,6 +2,7 @@ import { showInspector } from 'ai-jsx/core/inspector';
 import {
   ChatCompletion,
   ChatProvider,
+  FunctionDefinition,
   SystemMessage,
   UserMessage,
   FunctionCall,
@@ -22,7 +23,7 @@ function ModelProducesFunctionCall({ query }: { query: string }) {
               required: true,
             },
           },
-        },
+        } as FunctionDefinition,
       }}
     >
       <SystemMessage>You are a tool that may use functions to answer a user question.</SystemMessage>
@@ -46,7 +47,7 @@ function ModelProducesFinalResponse({ query }: { query: string }) {
                 required: true,
               },
             },
-          },
+          } as FunctionDefinition,
         }}
       >
         <SystemMessage>You are a tool that may use functions to answer a user question.</SystemMessage>

--- a/packages/examples/test/lib/openai.tsx
+++ b/packages/examples/test/lib/openai.tsx
@@ -14,7 +14,7 @@ describe('OpenAIChatModel', () => {
           chat: {
             completions: {
               async *create(req) {
-                expect(req.max_tokens).toBe(4096);
+                expect(req.max_tokens).toBe(10 ** 10);
                 expect(req.messages).toEqual([
                   expect.objectContaining({
                     content: 'Hello!',
@@ -27,7 +27,7 @@ describe('OpenAIChatModel', () => {
           },
         }}
       >
-        <ChatCompletion maxTokens={4096}>
+        <ChatCompletion maxTokens={10 ** 10}>
           <Shrinkable importance={0} replacement={<UserMessage>Hello!</UserMessage>}>
             <UserMessage>This should be replaced</UserMessage>
           </Shrinkable>
@@ -61,7 +61,7 @@ describe('OpenAIChatModel', () => {
           },
         }}
       >
-        <ChatCompletion reservedTokens={4096}>
+        <ChatCompletion reservedTokens={10 ** 10}>
           <Shrinkable importance={0} replacement={<UserMessage>Hello!</UserMessage>}>
             <UserMessage>This should be replaced</UserMessage>
           </Shrinkable>

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,19 +211,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.5.10":
-  version: 0.5.10
-  resolution: "@anthropic-ai/sdk@npm:0.5.10"
+"@anthropic-ai/sdk@npm:^0.20.1":
+  version: 0.20.1
+  resolution: "@anthropic-ai/sdk@npm:0.20.1"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
     abort-controller: ^3.0.0
     agentkeepalive: ^4.2.1
-    digest-fetch: ^1.3.0
     form-data-encoder: 1.7.2
     formdata-node: ^4.3.2
     node-fetch: ^2.6.7
-  checksum: 4f70b06be7be7e9baee0d2b85648f17643a58c89003331a9b38dea8e3eaea3519d60ac5ef2074b903897214f53358b92c6e87e7ea4f22787410cccb85d5a8b1b
+    web-streams-polyfill: ^3.2.1
+  checksum: a880088ffeb993ea835f3ec250d53bf6ba23e97c3dfc54c915843aa8cb4778849fb7b85de0a359155c36595a5a5cc1db64139d407d2e36a2423284ebfe763cce
   languageName: node
   linkType: hard
 
@@ -7107,7 +7107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ai-jsx@workspace:packages/ai-jsx"
   dependencies:
-    "@anthropic-ai/sdk": ^0.5.10
+    "@anthropic-ai/sdk": ^0.20.1
     "@jest/globals": ^29.5.0
     "@mdx-js/mdx": ^2.3.0
     "@nick.heiner/wandb-fork": ^0.5.2-5
@@ -12111,7 +12111,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples@workspace:packages/examples"
   dependencies:
-    "@anthropic-ai/sdk": ^0.5.10
+    "@anthropic-ai/sdk": ^0.20.1
     "@jest/globals": ^29.5.0
     "@opentelemetry/api": ^1.4.1
     "@opentelemetry/api-logs": ^0.41.1


### PR DESCRIPTION
- Update Anthropic SDK, switch to messages API, add support for beta tool use API
- Relax OpenAI function calling restrictions (all models support function calling now)
- Add `maxInputTokens` prop to `OpenAIChatModel` to support explicitly limiting prompt size
- Add new GPT-4 models to enum