### PR TITLE
Fix incorrect spread on children in jsx-runtime

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/jsx-runtime.ts
+++ b/packages/ai-jsx/src/jsx-runtime.ts
@@ -13,8 +13,7 @@ export declare namespace JSX {
 /** @hidden */
 export function jsx(type: any, config: any, maybeKey?: any) {
   const configWithKey = maybeKey !== undefined ? { ...config, key: maybeKey } : config;
-  const children = config && Array.isArray(config.children) ? config.children : [];
-  return AI.createElement(type, configWithKey, ...children);
+  return AI.createElement(type, configWithKey);
 }
 /** @hidden */
 export const jsxDEV = jsx;

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.30.2
+## 0.31.0
+
+- Fix incorrect unwrapping of JSX array `children`.
+
+## [0.30.2](https://github.com/fixie-ai/ai-jsx/tree/29071540b051a7a6db2b7986bc544debde82298a)
 
 - Fix double Anthropic requests
 


### PR DESCRIPTION
The built-in JSX runtime transformation already does this; doing it again has the effect of unwrapping single-element arrays.