### PR TITLE
Add support for images in UserMessages

### DIFF
--- a/packages/ai-jsx/package.json
+++ b/packages/ai-jsx/package.json
@@ -4,7 +4,7 @@
   "repository": "fixie-ai/ai-jsx",
   "bugs": "https://github.com/fixie-ai/ai-jsx/issues",
   "homepage": "https://ai-jsx.com",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "volta": {
     "extends": "../../package.json"
   },

--- a/packages/ai-jsx/src/core/conversation.tsx
+++ b/packages/ai-jsx/src/core/conversation.tsx
@@ -285,13 +285,13 @@ export async function renderToConversation(
   render: AI.ComponentContext['render'],
   logger?: AI.ComponentContext['logger'],
   logType?: 'prompt' | 'completion',
-  cost?: (message: ConversationMessage, render: AI.ComponentContext['render']) => Promise<number>,
+  cost?: (message: ConversationMessage) => Promise<number>,
   budget?: number
 ) {
   const cachedCosts = new WeakMap<AI.Element<any>, Promise<number>>();
   function cachedCost(message: ConversationMessage): Promise<number> {
     if (!cachedCosts.has(message.element)) {
-      cachedCosts.set(message.element, cost!(message, render));
+      cachedCosts.set(message.element, cost!(message));
     }
 
     return cachedCosts.get(message.element)!;

--- a/packages/ai-jsx/src/core/image-gen.tsx
+++ b/packages/ai-jsx/src/core/image-gen.tsx
@@ -89,15 +89,6 @@ export function ImageGen({ children, ...props }: ImageGenPropsWithChildren, { ge
   );
 }
 
-export interface GeneratedImageProps {
-  /** The image URL. */
-  url: string;
-  /** The prompt used for generating the image. Currently only used for debugging.  */
-  prompt: string;
-  /** The model used for generating the image. Currently only used for debugging. */
-  modelName: string;
-}
-
 /**
  * This component represents an image via a single `url` prop.
  * It is a wrapper for the output of {@link ImageGen} to allow for first-class support of images.
@@ -106,6 +97,17 @@ export interface GeneratedImageProps {
  * - In terminal-based environments, this component will be rendered as a URL.
  * - In browser-based environments, this component will be rendered as an `img` tag.
  */
-export function Image(props: GeneratedImageProps) {
+export function Image(props: {
+  /** The image URL. */
+  url: string;
+  /** The prompt used for generating the image. Currently only used for debugging.  */
+  prompt?: string;
+  /** The model used for generating the image. Currently only used for debugging. */
+  modelName?: string;
+  /** The level of detail required. */
+  detail?: string;
+  /** The number of input tokens required. */
+  inputTokens?: number;
+}) {
   return props.url;
 }

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.32.0
+## 0.33.0
+
+- Add support for passing `<Image>` to OpenAI models.
+
+## [0.32.0](https://github.com/fixie-ai/ai-jsx/tree/e7b3e2e444659a49e04693337c2af023c506fbe6)
 
 - Improve rendering performance:
   - Change `<ShrinkConversation>` to cache token costs when remeasuring the same elements

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -63,6 +63,7 @@
     "demo:image-generation": "yarn build && node dist/src/image-generation.js",
     "demo:shrink": "yarn build && node dist/src/conversation-shrinking.js",
     "demo:fixie-corpus": "yarn build && node dist/src/fixie-corpus.js",
+    "demo:vision": "yarn build && node dist/src/vision.js",
     "view-logs": "cat ai-jsx.log | pino-pretty",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/packages/examples/src/vision.tsx
+++ b/packages/examples/src/vision.tsx
@@ -1,0 +1,23 @@
+import { ChatCompletion, UserMessage } from 'ai-jsx/core/completion';
+import { Image } from 'ai-jsx/core/image-gen';
+import { showInspector } from 'ai-jsx/core/inspector';
+import { OpenAI } from 'ai-jsx/lib/openai';
+
+function App() {
+  return (
+    <OpenAI chatModel="gpt-4-turbo">
+      <ChatCompletion>
+        <UserMessage>
+          What do the following images have in common?
+          <Image url="https://upload.wikimedia.org/wikipedia/commons/8/89/Apollo_11_bootprint.jpg" detail="low" />
+          <Image
+            url="https://upload.wikimedia.org/wikipedia/commons/3/36/PIA00563-Viking1-FirstColorImage-19760721.jpg"
+            detail="low"
+          />
+        </UserMessage>
+      </ChatCompletion>
+    </OpenAI>
+  );
+}
+
+showInspector(<App />);


### PR DESCRIPTION
This adds support for passing images as inputs to OpenAI models. They can be embedded in `<UserMessage>`s using the existing `<Image>` tag.

By default `OpenAIChatModel` passes images for models that supports it, but this can be forced (or denied) by setting the `includeImages` props explicitly.